### PR TITLE
refs #87 Bookmarks RSS Feed Content Broken

### DIFF
--- a/apps/entry/views.py
+++ b/apps/entry/views.py
@@ -57,6 +57,7 @@ class CreateEntryView(CreateView):
         context = super().get_context_data(nav="posts", **kwargs)
         if "named_forms" not in context:
             context["named_forms"] = self.get_named_forms()
+        context["page_title"] = "Create Post"
         return context
 
     def form_invalid(self, form, named_forms=None):
@@ -99,6 +100,7 @@ class UpdateEntryView(UpdateView):
         context = super().get_context_data(nav="posts", **kwargs)
         if "named_forms" not in context:
             context["named_forms"] = self.get_named_forms()
+        context["page_title"] = "Edit Post"
         return context
 
     def get_named_forms(self):

--- a/apps/feeds/views.py
+++ b/apps/feeds/views.py
@@ -6,6 +6,7 @@ from post.models import TPost
 from streams.models import MStream
 from entry.models import TLocation
 from indieweb.constants import MPostKinds
+from settings.models import MSiteSettings
 
 
 class ExtendedRSSFeed(Rss201rev2Feed):
@@ -24,9 +25,12 @@ class ExtendedRSSFeed(Rss201rev2Feed):
 
 
 class AllEntriesFeed(Feed):
-    title = "Tanzawa"
     feed_type = ExtendedRSSFeed
     item_guid_is_permalink = False
+
+    def title(self):
+        title = MSiteSettings.objects.values_list("title", flat=True).first()
+        return title or "Tanzawa"
 
     def link(self):
         return reverse("feeds:feed")

--- a/apps/feeds/views.py
+++ b/apps/feeds/views.py
@@ -61,7 +61,7 @@ class AllEntriesFeed(Feed):
             e_content = (
                 f"Bookmark: "
                 f'<a href="{t_bookmark.u_bookmark_of}"'
-                ">{t_bookmark.title or t_bookmark.u_bookmark_of}</a>"
+                f">{t_bookmark.title or t_bookmark.u_bookmark_of}</a>"
                 f"<blockquote>{t_bookmark.quote}</blockquote>{e_content}"
             )
         try:


### PR DESCRIPTION
Bookmark content for RSS feeds were broken. The root cause was a missing f before the string, so the content was not processed as an f-string.

This PR also fixes the feed title to use the site name, rather than hard-coded to "Tanzawa" and adds page titles when creating/editing a post.