### PR TITLE
refs #35 prevent unlisted posts from appearing in streams :doh:

### DIFF
--- a/apps/feeds/views.py
+++ b/apps/feeds/views.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.utils.feedgenerator import Rss201rev2Feed
 from post.models import TPost
 from streams.models import MStream
+from core.constants import Visibility
 from entry.models import TLocation
 from indieweb.constants import MPostKinds, MPostStatuses
 from settings.models import MSiteSettings
@@ -43,6 +44,7 @@ class AllEntriesFeed(Feed):
         return (
             TPost.objects.visible_for_user(self.request.user.id)
             .filter(m_post_status__key=MPostStatuses.published)
+            .exclude(visibility=Visibility.UNLISTED)
             .select_related("m_post_kind")
             .prefetch_related(
                 "ref_t_entry",
@@ -103,6 +105,7 @@ class StreamFeed(AllEntriesFeed):
         return (
             TPost.objects.visible_for_user(self.request.user.id)
             .filter(streams=obj, m_post_status__key=MPostStatuses.published)
+            .exclude(visibility=Visibility.UNLISTED)
             .select_related("ref_t_entry")
             .all()
             .order_by("-dt_published")[:10]

--- a/apps/public/views.py
+++ b/apps/public/views.py
@@ -7,6 +7,7 @@ from django.utils.timezone import now
 from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
 from entry.models import TEntry
+from core.constants import Visibility
 from indieweb.constants import MPostStatuses
 from post.models import TPost
 from streams.models import MStream
@@ -32,6 +33,7 @@ class HomeView(ListView):
                 "t_checkin",
             )
             .filter(t_post__m_post_status__key=MPostStatuses.published)
+            .exclude(t_post__visibility=Visibility.UNLISTED)
             .annotate(
                 interaction_count=Count(
                     "t_post__ref_t_webmention",
@@ -94,6 +96,7 @@ class AuthorDetail(ListView):
     def get_queryset(self):
         return (
             TEntry.objects.visible_for_user(self.request.user.id)
+            .exclude(t_post__visibility=Visibility.UNLISTED)
             .select_related(
                 "t_post",
                 "t_post__m_post_kind",
@@ -129,6 +132,7 @@ class StreamView(ListView):
 
         return (
             TEntry.objects.visible_for_user(self.request.user.id)
+            .exclude(t_post__visibility=Visibility.UNLISTED)
             .select_related(
                 "t_post",
                 "t_post__m_post_kind",
@@ -177,6 +181,7 @@ class SearchView(ListView):
     def get_queryset(self):
         qs = (
             TEntry.objects.visible_for_user(self.request.user.id)
+            .exclude(t_post__visibility=Visibility.UNLISTED)
             .select_related(
                 "t_post",
                 "t_post__m_post_kind",

--- a/tests/test_feeds/test_feed.py
+++ b/tests/test_feeds/test_feed.py
@@ -47,13 +47,13 @@ class TestFeedView:
         [
             (Visibility.PUBLIC, pytest.lazy_fixture("published_status"), True, None),
             (Visibility.PRIVATE, pytest.lazy_fixture("published_status"), False, None),
-            (Visibility.UNLISTED, pytest.lazy_fixture("published_status"), True, None),
+            (Visibility.UNLISTED, pytest.lazy_fixture("published_status"), False, None),
             (Visibility.PUBLIC, pytest.lazy_fixture("published_status"), True, pytest.lazy_fixture("author")),
             (Visibility.PRIVATE, pytest.lazy_fixture("published_status"), True, pytest.lazy_fixture("author")),
-            (Visibility.UNLISTED, pytest.lazy_fixture("published_status"), True, pytest.lazy_fixture("author")),
+            (Visibility.UNLISTED, pytest.lazy_fixture("published_status"), False, pytest.lazy_fixture("author")),
             (Visibility.PUBLIC, pytest.lazy_fixture("published_status"), True, pytest.lazy_fixture("another_user")),
             (Visibility.PRIVATE, pytest.lazy_fixture("published_status"), False, pytest.lazy_fixture("another_user")),
-            (Visibility.UNLISTED, pytest.lazy_fixture("published_status"), True, pytest.lazy_fixture("another_user")),
+            (Visibility.UNLISTED, pytest.lazy_fixture("published_status"), False, pytest.lazy_fixture("another_user")),
             # Draft Status
             (Visibility.PUBLIC, pytest.lazy_fixture("draft_status"), False, None),
             (Visibility.PRIVATE, pytest.lazy_fixture("draft_status"), False, None),

--- a/tests/test_feeds/test_stream_feed.py
+++ b/tests/test_feeds/test_stream_feed.py
@@ -50,13 +50,13 @@ class TestStreamFeedView:
         [
             (Visibility.PUBLIC, pytest.lazy_fixture("published_status"), True, None),
             (Visibility.PRIVATE, pytest.lazy_fixture("published_status"), False, None),
-            (Visibility.UNLISTED, pytest.lazy_fixture("published_status"), True, None),
+            (Visibility.UNLISTED, pytest.lazy_fixture("published_status"), False, None),
             (Visibility.PUBLIC, pytest.lazy_fixture("published_status"), True, pytest.lazy_fixture("author")),
             (Visibility.PRIVATE, pytest.lazy_fixture("published_status"), True, pytest.lazy_fixture("author")),
-            (Visibility.UNLISTED, pytest.lazy_fixture("published_status"), True, pytest.lazy_fixture("author")),
+            (Visibility.UNLISTED, pytest.lazy_fixture("published_status"), False, pytest.lazy_fixture("author")),
             (Visibility.PUBLIC, pytest.lazy_fixture("published_status"), True, pytest.lazy_fixture("another_user")),
             (Visibility.PRIVATE, pytest.lazy_fixture("published_status"), False, pytest.lazy_fixture("another_user")),
-            (Visibility.UNLISTED, pytest.lazy_fixture("published_status"), True, pytest.lazy_fixture("another_user")),
+            (Visibility.UNLISTED, pytest.lazy_fixture("published_status"), False, pytest.lazy_fixture("another_user")),
             # Draft Status
             (Visibility.PUBLIC, pytest.lazy_fixture("draft_status"), False, None),
             (Visibility.PRIVATE, pytest.lazy_fixture("draft_status"), False, None),

--- a/tests/test_public/test_author_view.py
+++ b/tests/test_public/test_author_view.py
@@ -49,13 +49,13 @@ class TestAuthorView:
         [
             (Visibility.PUBLIC, True, None),
             (Visibility.PRIVATE, False, None),
-            (Visibility.UNLISTED, True, None),
+            (Visibility.UNLISTED, False, None),
             (Visibility.PUBLIC, True, pytest.lazy_fixture("author")),
             (Visibility.PRIVATE, True, pytest.lazy_fixture("author")),
-            (Visibility.UNLISTED, True, pytest.lazy_fixture("author")),
+            (Visibility.UNLISTED, False, pytest.lazy_fixture("author")),
             (Visibility.PUBLIC, True, pytest.lazy_fixture("another_user")),
             (Visibility.PRIVATE, False, pytest.lazy_fixture("another_user")),
-            (Visibility.UNLISTED, True, pytest.lazy_fixture("another_user")),
+            (Visibility.UNLISTED, False, pytest.lazy_fixture("another_user")),
         ],
     )
     def test_respects_visibility(

--- a/tests/test_public/test_home_view.py
+++ b/tests/test_public/test_home_view.py
@@ -46,13 +46,13 @@ class TestHomeView:
         [
             (Visibility.PUBLIC, True, None),
             (Visibility.PRIVATE, False, None),
-            (Visibility.UNLISTED, True, None),
+            (Visibility.UNLISTED, False, None),
             (Visibility.PUBLIC, True, pytest.lazy_fixture("author")),
             (Visibility.PRIVATE, True, pytest.lazy_fixture("author")),
-            (Visibility.UNLISTED, True, pytest.lazy_fixture("author")),
+            (Visibility.UNLISTED, False, pytest.lazy_fixture("author")),
             (Visibility.PUBLIC, True, pytest.lazy_fixture("another_user")),
             (Visibility.PRIVATE, False, pytest.lazy_fixture("another_user")),
-            (Visibility.UNLISTED, True, pytest.lazy_fixture("another_user")),
+            (Visibility.UNLISTED, False, pytest.lazy_fixture("another_user")),
         ],
     )
     def test_respects_visibility(

--- a/tests/test_public/test_search_view.py
+++ b/tests/test_public/test_search_view.py
@@ -49,13 +49,13 @@ class TestSearchView:
         [
             (Visibility.PUBLIC, True, None),
             (Visibility.PRIVATE, False, None),
-            (Visibility.UNLISTED, True, None),
+            (Visibility.UNLISTED, False, None),
             (Visibility.PUBLIC, True, pytest.lazy_fixture("author")),
             (Visibility.PRIVATE, True, pytest.lazy_fixture("author")),
-            (Visibility.UNLISTED, True, pytest.lazy_fixture("author")),
+            (Visibility.UNLISTED, False, pytest.lazy_fixture("author")),
             (Visibility.PUBLIC, True, pytest.lazy_fixture("another_user")),
             (Visibility.PRIVATE, False, pytest.lazy_fixture("another_user")),
-            (Visibility.UNLISTED, True, pytest.lazy_fixture("another_user")),
+            (Visibility.UNLISTED, False, pytest.lazy_fixture("another_user")),
         ],
     )
     def test_respects_visibility(

--- a/tests/test_public/test_stream_view.py
+++ b/tests/test_public/test_stream_view.py
@@ -49,13 +49,13 @@ class TestStreamView:
         [
             (Visibility.PUBLIC, True, None),
             (Visibility.PRIVATE, False, None),
-            (Visibility.UNLISTED, True, None),
+            (Visibility.UNLISTED, False, None),
             (Visibility.PUBLIC, True, pytest.lazy_fixture("author")),
             (Visibility.PRIVATE, True, pytest.lazy_fixture("author")),
-            (Visibility.UNLISTED, True, pytest.lazy_fixture("author")),
+            (Visibility.UNLISTED, False, pytest.lazy_fixture("author")),
             (Visibility.PUBLIC, True, pytest.lazy_fixture("another_user")),
             (Visibility.PRIVATE, False, pytest.lazy_fixture("another_user")),
-            (Visibility.UNLISTED, True, pytest.lazy_fixture("another_user")),
+            (Visibility.UNLISTED, False, pytest.lazy_fixture("another_user")),
         ],
     )
     def test_respects_visibility(


### PR DESCRIPTION
Just as the title says. My parameterized unit tests for lists were the same as the permalink view. Unlisted posts should be accessible via the URL (if you know it) but they should not appear in any list publicly (even if you're logged in / it's your post)