### PR TITLE
Fix saving checkins submit button

### DIFF
--- a/apps/templates/entry/checkin/_form.html
+++ b/apps/templates/entry/checkin/_form.html
@@ -1,4 +1,4 @@
-<form  id="checkin" method="POST" class="flex-col" data-turbo="false">
+<form  id="entry" method="POST" class="flex-col" data-turbo="false">
     {% csrf_token %}
     {{ form.errors }}
     {% for named_form in named_forms %}


### PR DESCRIPTION
With #35 the form id when editing posts was unified from the post type ( i.e. `note`, `article` etc..) to `entry`. I missed the checkin edit screen. This PR allows you to save checkins again.