### PR TITLE
Remove Title Tag From Checkin and Note RSS Feed

### DIFF
--- a/apps/feeds/views.py
+++ b/apps/feeds/views.py
@@ -1,7 +1,7 @@
 from django.contrib.syndication.views import Feed
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
-from django.utils.feedgenerator import Rss201rev2Feed
+from django.utils.feedgenerator import Rss201rev2Feed, rfc2822_date
 from post.models import TPost
 from streams.models import MStream
 from core.constants import Visibility
@@ -20,8 +20,63 @@ class ExtendedRSSFeed(Rss201rev2Feed):
         attrs["xmlns:content"] = "http://purl.org/rss/1.0/modules/content/"
         return attrs
 
-    def add_item_elements(self, handler, item):
-        super().add_item_elements(handler, item)
+    def add_item_elements(self, handler, item):  # noqa: C901
+        """
+        Overrides the base class because there's no hook around the title tag.
+        Excluding the title tag if no title is set to allow checkins and notes to display inline
+        on micro.blog
+        """
+        if item["title"]:
+            handler.addQuickElement("title", item["title"])
+        # Django super start
+        handler.addQuickElement("link", item["link"])
+        if item["description"] is not None:
+            handler.addQuickElement("description", item["description"])
+
+        # Author information.
+        if item["author_name"] and item["author_email"]:
+            handler.addQuickElement("author", "%s (%s)" % (item["author_email"], item["author_name"]))
+        elif item["author_email"]:
+            handler.addQuickElement("author", item["author_email"])
+        elif item["author_name"]:
+            handler.addQuickElement("dc:creator", item["author_name"], {"xmlns:dc": "http://purl.org/dc/elements/1.1/"})
+
+        if item["pubdate"] is not None:
+            handler.addQuickElement("pubDate", rfc2822_date(item["pubdate"]))
+        if item["comments"] is not None:
+            handler.addQuickElement("comments", item["comments"])
+        if item["unique_id"] is not None:
+            guid_attrs = {}
+            if isinstance(item.get("unique_id_is_permalink"), bool):
+                guid_attrs["isPermaLink"] = str(item["unique_id_is_permalink"]).lower()
+            handler.addQuickElement("guid", item["unique_id"], guid_attrs)
+        if item["ttl"] is not None:
+            handler.addQuickElement("ttl", item["ttl"])
+
+        # Enclosure.
+        if item["enclosures"]:
+            enclosures = list(item["enclosures"])
+            if len(enclosures) > 1:
+                raise ValueError(
+                    "RSS feed items may only have one enclosure, see "
+                    "http://www.rssboard.org/rss-profile#element-channel-item-enclosure"
+                )
+            enclosure = enclosures[0]
+            handler.addQuickElement(
+                "enclosure",
+                "",
+                {
+                    "url": enclosure.url,
+                    "length": enclosure.length,
+                    "type": enclosure.mime_type,
+                },
+            )
+
+        # Categories.
+        for cat in item["categories"]:
+            handler.addQuickElement("category", cat)
+        # Django Superclass End
+        # Add our html content to the feed
         handler.addQuickElement("content:encoded", item["content_encoded"])
 
 


### PR DESCRIPTION
This commit physically removes the title tag from RSS items that do not have a title. Again as an attempt to get micro.blog to render checkins and notes inline.