### PR TITLE
Fix Post Status Ordering and Empty Bookmark/Reply Context Widget

### DIFF
--- a/apps/entry/forms.py
+++ b/apps/entry/forms.py
@@ -151,7 +151,9 @@ class CreateReplyForm(CreateStatusForm):
         self.fields["e_content"].label = "My Response"
         self.t_reply: Optional[TReply] = None
         for key, val in self.initial.items():
-            if not val:
+            if val:
+                continue
+            if isinstance(self.fields[key].widget, forms.HiddenInput):
                 self.fields[key].widget = forms.TextInput(attrs={"class": "input-field"})
 
     def prepare_data(self):
@@ -337,7 +339,9 @@ class CreateBookmarkForm(CreateStatusForm):
         self.fields["e_content"].label = "Comment"
         self.t_bookmark: Optional[TBookmark] = None
         for key, val in self.initial.items():
-            if not val:
+            if val:
+                continue
+            if isinstance(self.fields[key].widget, forms.HiddenInput):
                 self.fields[key].widget = forms.TextInput(attrs={"class": "input-field"})
 
     def prepare_data(self):


### PR DESCRIPTION
This PR fixes two minor issues that have been frustrating when using Tanzawa

* Order "Is Published?" Menu Alphabetically
* Set HiddenFields to Text If No Value
  Fixes an issue where replies/bookmarks without a context
    e.g. a tweet would have the TextArea widget replaced with a regular
    TextInput, making it difficult to paste in longer context blocks for
    those posts.
 
