### PR TITLE
Gracefully Restart Web Server When Plugin Enabled / Disabled via Web

### DIFF
--- a/apps/plugins/views.py
+++ b/apps/plugins/views.py
@@ -3,6 +3,7 @@ from django.contrib.auth import decorators as auth_decorators
 from django.shortcuts import redirect, render
 from django.views.decorators import http
 from plugins import pool
+from plugins.application import activation
 
 
 @auth_decorators.login_required
@@ -24,6 +25,7 @@ def enable_plugin(request, identifier: str):
         return redirect("plugins:plugin_list")
     pool.plugin_pool.enable(plugin)
     messages.success(request, f"{plugin.name} enabled.")
+    activation.restart_parent_process()
     return redirect("plugins:plugin_list")
 
 
@@ -36,4 +38,5 @@ def disable_plugin(request, identifier: str):
         return redirect("plugins:plugin_list")
     pool.plugin_pool.disable(plugin)
     messages.success(request, f"{plugin.name} disabled.")
+    activation.restart_parent_process()
     return redirect("plugins:plugin_list")


### PR DESCRIPTION
This PR adds in a process to gracefully restart gunicorn/uWSGI servers after enabling or disabling a plugin. The reason this is necessary is because while modifying INSTALLED_APPS and clearing caches works in development, it only effects a single process. This is an issue when you have multiple processes as every process besides the one that handled the activation request is still operating as if the plugin has not been enabled. This will cause them to throw errors if you try to resolve plugin specific URLs as the routes do not exist for those processes. 