### PR TITLE
Indieauth no longer requires scope or me parameters

### DIFF
--- a/apps/indieweb/forms.py
+++ b/apps/indieweb/forms.py
@@ -16,6 +16,6 @@ class IndieAuthAuthorizationForm(forms.Form):
     scope = forms.ModelMultipleChoiceField(
         MMicropubScope.objects,
         to_field_name="key",
-        required=True,
+        required=False,
         widget=MMicropubCheckboxWidget,
     )

--- a/apps/indieweb/serializers.py
+++ b/apps/indieweb/serializers.py
@@ -170,11 +170,11 @@ ResponseTypeChoices = [("id", "id"), ("code", "id+authorization")]
 
 class IndieAuthAuthorizationSerializer(serializers.Serializer):
 
-    me = serializers.URLField(required=True)
+    me = serializers.URLField(required=False)
     client_id = serializers.URLField(required=True)
     redirect_uri = serializers.URLField(required=True)
     state = serializers.CharField(required=True)
-    scope = serializers.CharField(required=True)
+    scope = serializers.CharField(required=False)
     response_type = serializers.ChoiceField(choices=ResponseTypeChoices, required=False, initial="id")
 
     def validate(self, data):


### PR DESCRIPTION
This commit brings the indieauth authorization api into line with the specs.
Authorization requests to indieauth can be made without a "scope" parameter.
In such a case we should not create a token record and not return any code value.

Addresses #160 