### PR TITLE
Add favicon view

### DIFF
--- a/apps/core/urls.py
+++ b/apps/core/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
     path("webmention/", include("webmention.urls")),
     path("admin/", admin.site.urls),
     path("auth/", include("django.contrib.auth.urls")),
+    path("favicon.ico", views.favicon),
 ]
 
 # Include any plugin urls after core urls.

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -1,7 +1,14 @@
 from typing import Optional
 
-from django.http import HttpResponseNotFound, HttpResponsePermanentRedirect
+from django.http import (
+    HttpRequest,
+    HttpResponse,
+    HttpResponseNotFound,
+    HttpResponsePermanentRedirect,
+)
 from django.urls import reverse
+from django.views.decorators.cache import cache_control
+from django.views.decorators.http import require_GET
 from wordpress.models import TCategory, TWordpressPost
 
 
@@ -25,3 +32,19 @@ def handle404(request, exception):
                 # Redirect to stream page
                 return HttpResponsePermanentRedirect(reverse("public:stream", args=[t_category.m_stream.slug]))
     return HttpResponseNotFound()
+
+
+@require_GET
+@cache_control(max_age=60 * 60 * 24, immutable=True, public=True)  # one day
+def favicon(request: HttpRequest) -> HttpResponse:
+
+    return HttpResponse(
+        (
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">'
+            + '<text y=".9em" font-size="90">'
+            + request.settings.icon
+            + "</text>"
+            + "</svg>"
+        ),
+        content_type="image/svg+xml",
+    )

--- a/apps/templates/base_public.html
+++ b/apps/templates/base_public.html
@@ -6,7 +6,7 @@
     <meta name="viewport"
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>{% if title %}{{ title }} - {% endif %}🏔 {{ request.settings.title }}</title>
+    <title>{% if title %}{{ title }} - {% endif %}{{ request.settings.title }}</title>
     {% with request.scheme|add:"://"|add:request.get_host as absolute_url %}
     <link rel="alternate" type="application/rss+xml" title="{% if request.settings.icon %}{{ request.settings.icon }} {% endif %}{{ request.settings.title }}" href="{{ absolute_url }}{% url 'feeds:feed' %}">
     {% if stream %}


### PR DESCRIPTION
Adds a favicon view and caches the response for 1 day. Generates a svg of a site icon. Code from [Adam Johnson's](https://adamj.eu/tech/2022/01/18/how-to-add-a-favicon-to-your-django-site/) blog.