### PR TITLE
Extract new post links from menu on mobile

### DIFF
--- a/apps/templates/base.html
+++ b/apps/templates/base.html
@@ -53,12 +53,9 @@
 
                     <li class="{% if nav == 'settings' %}selected{% endif %} w-28 p-1 mb-2" data-select-target="menuItem"><a href="{% url 'admin:index' %}"><span class="mr-1">⚙️</span><span>Settings</span></a></li>
                 </ul>
-                 <div data-reveal-target="item" class="mb-2 hidden md:hidden mt-2">
-                     {% include "fragments/create_post_menu.html" %}
-                 </div>
             </nav>
         </header>
-        <div class="flex">
+        <div class="md:flex">
             <nav id="section-nav" class="min-w-min p-2 flex flex-col hidden md:block">
                 <ul class="mb-2" data-controller="select" data-select-selected-class="selected">
                     <li class="{% if nav == 'dashboard' %}selected{% endif %} w-28 p-1 mb-2" data-select-target="menuItem"><a href="{% url "post:dashboard" %}" data-turbo-frame="_top" data-action="select#click"><span class="mr-1">🏡</span><span>Home</span></a></li>
@@ -69,6 +66,14 @@
                     <li class="{% if nav == 'settings' %}selected{% endif %} w-28 p-1 mb-2" data-select-target="menuItem"><a href="{% url 'admin:index' %}"><span class="mr-1">⚙️</span><span>Settings</span></a></li>
                 </ul>
             </nav>
+            {% if nav == "dashboard" %}
+                <div class="mx-auto mx-2 grid grid-cols-2 gap-2 md:hidden">
+                    <a href="{% url "status_create" %}" data-turbo-frame="_top" class="primary-button"><span class="mr-1">💬</span><span class="hover:underline">New Status</span></a>
+                    <a href="{% url "article_create" %}" data-turbo-frame="_top" class="primary-button"><span class="mr-1">✏️</span><span class="hover:underline">New Article</span></a>
+                    <a href="{% url "reply_create" %}" data-turbo-frame="_top" class="primary-button"><span class="mr-1">📤️</span><span class="hover:underline">New Reply</span></a>
+                    <a href="{% url "bookmark_create" %}" data-turbo-frame="_top" class="primary-button"><span class="mr-1">🔖️</span><span class="hover:underline">New Bookmark</span></a>
+                </div>
+            {% endif %}
             <div id="content" class="w-11/12 flex flex-col">
                 {% block content %}
                 {% include "fragments/content.html" %}

--- a/apps/templates/base.html
+++ b/apps/templates/base.html
@@ -35,6 +35,7 @@
                                 <span class="mr-1">{{ request.settings.icon }}</span>
                             {% endif %}{{ request.settings.title }} Admin
                         </a>
+                    </h1>
                     <div class="ml-auto pt-2 md:hidden">
                         <button data-reveal-target="button" data-action="click->reveal#toggle">
                             <div class="w-8 bg-negroni-700 h-1"></div>

--- a/static/tailwind/style.css
+++ b/static/tailwind/style.css
@@ -494,13 +494,13 @@ Ensure the default browser behavior of the `hidden` attribute.
   margin-left: auto;
   margin-right: auto;
 }
-.my-2 {
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
-}
 .mx-2 {
   margin-left: 0.5rem;
   margin-right: 0.5rem;
+}
+.my-2 {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 .mb-1 {
   margin-bottom: 0.25rem;
@@ -576,6 +576,9 @@ Ensure the default browser behavior of the `hidden` attribute.
 }
 .table {
   display: table;
+}
+.grid {
+  display: grid;
 }
 .hidden {
   display: none;
@@ -696,6 +699,9 @@ Ensure the default browser behavior of the `hidden` attribute.
 .grid-flow-col {
   grid-auto-flow: column;
 }
+.grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
 .flex-col {
   flex-direction: column;
 }
@@ -713,6 +719,9 @@ Ensure the default browser behavior of the `hidden` attribute.
 }
 .justify-between {
   justify-content: space-between;
+}
+.gap-2 {
+  gap: 0.5rem;
 }
 .gap-4 {
   gap: 1rem;
@@ -797,6 +806,10 @@ Ensure the default browser behavior of the `hidden` attribute.
   --tw-bg-opacity: 1;
   background-color: rgb(251 247 239 / var(--tw-bg-opacity));
 }
+.bg-secondary {
+  --tw-bg-opacity: 1;
+  background-color: rgb(120 105 91 / var(--tw-bg-opacity));
+}
 .bg-malachite-800 {
   --tw-bg-opacity: 1;
   background-color: rgb(20 140 54 / var(--tw-bg-opacity));
@@ -804,10 +817,6 @@ Ensure the default browser behavior of the `hidden` attribute.
 .bg-malachite-200 {
   --tw-bg-opacity: 1;
   background-color: rgb(200 250 214 / var(--tw-bg-opacity));
-}
-.bg-secondary {
-  --tw-bg-opacity: 1;
-  background-color: rgb(120 105 91 / var(--tw-bg-opacity));
 }
 .bg-bianca-900 {
   --tw-bg-opacity: 1;


### PR DESCRIPTION
This PR moves the new post links from a `<details>` tag inside the hamburger menu on mobile to nice big blocky buttons on the dashboard. This removes 2 taps when creating a new post.

Before:
<img width="218" alt="image" src="https://user-images.githubusercontent.com/154726/151066917-82775f65-9b1b-4fb5-8f98-4bf94def8d3f.png">

After:
<img width="374" alt="image" src="https://user-images.githubusercontent.com/154726/151066607-cd1ca240-ea12-4a14-b92e-7dcd76cd3cd2.png">
