### PR TITLE
Fix indieauth token

### DIFF
--- a/apps/indieweb/domain/indieauth/queries.py
+++ b/apps/indieweb/domain/indieauth/queries.py
@@ -1,3 +1,4 @@
+from django.urls import reverse
 from indieweb.models import TToken
 
 
@@ -26,3 +27,7 @@ def get_user_for_token(*, key: str):
 
 def get_new_token() -> str:
     return TToken.generate_key()
+
+
+def get_me_url(*, request, t_token: TToken) -> str:
+    return request.build_absolute_uri(reverse("public:author", args=[t_token.user.username]))

--- a/tests/test_indieweb/test_indieauth.py
+++ b/tests/test_indieweb/test_indieauth.py
@@ -36,7 +36,7 @@ class TestIndieAuthExchangeToken:
 
         data = response.json()
 
-        assert data["me"] == post_data["me"]
+        assert data["me"] == f"http://testserver/author/{t_token.user.username}/"
         assert len(data["access_token"]) == 40
         assert data["scope"] == "create update"
 


### PR DESCRIPTION
Updates the token response to include a `"me"` URL again, fixing login with tools like Quill.