### PR TITLE
Introduce packer

### DIFF
--- a/packer/base_server/README.md
+++ b/packer/base_server/README.md
@@ -1,0 +1,53 @@
+# Base Server
+
+This is the packer configuration for a base Ubuntu server that will run a Tanzawa in a container.
+It's designed to be used to create VMs that run as Digital Ocean droplets etc...
+
+## Installs
+
+The base server automatically installs the following packages
+
+* Docker
+* Nginx
+* Certbot
+
+## Configurations
+
+This server is setup to automatically:
+
+* Apply security patches _weekly_.
+* Look for Tanzawa upgrades _daily_.
+
+
+## Paths
+
+The Tanzawa container is setup to store all data outside of the container.
+
+|Component|Path|Notes|
+|---|---|---|
+|database|/opt/tanzawa/db.sqlite3|
+|file uploads|/opt/tanzawa/media/|
+|plugins|/opt/tanzawa/plugins/|
+|themes|/opt/tanzawa/themes/|
+|static resources|/opt/tanzawa/staticfiles|Publicly accessible by nginx|
+
+
+## Variables
+
+## Building
+
+Build a new image.
+
+```
+$ packer build base_server.pkr.hcl
+```
+
+Format the packer configurations.
+
+```
+$ packer fmt .
+```
+
+
+
+

--- a/packer/base_server/README.md
+++ b/packer/base_server/README.md
@@ -30,6 +30,16 @@ The Tanzawa container is setup to store all data outside of the container.
 |plugins|/opt/tanzawa/plugins/|
 |themes|/opt/tanzawa/themes/|
 |static resources|/opt/tanzawa/staticfiles|Publicly accessible by nginx|
+|tanzawa socket|/var/run/tanzawa/tanzawa.sock||
+|server name config|/opt/tanzawa/server_name|Used to configure the domain by nginx|
+
+### Server Name Config
+
+The server name config is included directly in the nginx config. It should match the following format:
+
+```
+server_name example.com;
+```
 
 
 ## Variables

--- a/packer/base_server/base_server.pkr.hcl
+++ b/packer/base_server/base_server.pkr.hcl
@@ -17,11 +17,16 @@ build {
   sources = [
     "source.docker.ubuntu"
   ]
+  provisioner "file" {
+    source="setup/weekly_update.sh"
+    destination= "/tmp/weekly_update.sh"
+  }
   provisioner "shell" {
     environment_vars = []
     scripts = [
       "setup/base_install.sh"
     ]
   }
+
 
 }

--- a/packer/base_server/base_server.pkr.hcl
+++ b/packer/base_server/base_server.pkr.hcl
@@ -12,15 +12,23 @@ source "docker" "ubuntu" {
   commit = true
 }
 
+source "digitalocean" "example" {
+  image        = "ubuntu-20-04-x64"
+  region       = "nyc3"
+  size         = "s-1vcpu-1gb"
+  ssh_username = "root"
+}
+
+
 variable "server_name" {
   default = env("SERVER_NAME")
 }
 
+
 build {
-  name = "Base Tanzawa Server"
-  sources = [
-    "source.docker.ubuntu"
-  ]
+  name = "Tanzawa Droplet"
+  sources = ["source.digitalocean.example"]
+  # sources = ["source.docker.ubuntu"]
   provisioner "file" {
     sources = [
       "setup/weekly_update.sh",

--- a/packer/base_server/base_server.pkr.hcl
+++ b/packer/base_server/base_server.pkr.hcl
@@ -12,17 +12,35 @@ source "docker" "ubuntu" {
   commit = true
 }
 
+variable "server_name" {
+  default = env("SERVER_NAME")
+}
+
 build {
   name = "Base Tanzawa Server"
   sources = [
     "source.docker.ubuntu"
   ]
   provisioner "file" {
-    source="setup/weekly_update.sh"
-    destination= "/tmp/weekly_update.sh"
+    sources = [
+      "setup/weekly_update.sh",
+      "templates/nginx.conf",
+      "templates/uwsgi_params",
+    ]
+    destination = "/tmp/"
   }
   provisioner "shell" {
-    environment_vars = []
+    environment_vars = [
+      "SERVER_NAME=${var.server_name}"
+    ]
+    inline = [
+      "mkdir -p /opt/tanzawa",
+      # Prepare Server Name include
+      "echo \"server_name $SERVER_NAME;\" >> /opt/tanzawa/server_name"
+
+    ]
+  }
+  provisioner "shell" {
     scripts = [
       "setup/base_install.sh"
     ]

--- a/packer/base_server/base_server.pkr.hcl
+++ b/packer/base_server/base_server.pkr.hcl
@@ -1,0 +1,27 @@
+packer {
+  required_plugins {
+    docker = {
+      version = ">= 0.0.7"
+      source  = "github.com/hashicorp/docker"
+    }
+  }
+}
+
+source "docker" "ubuntu" {
+  image  = "ubuntu:xenial"
+  commit = true
+}
+
+build {
+  name = "Base Tanzawa Server"
+  sources = [
+    "source.docker.ubuntu"
+  ]
+  provisioner "shell" {
+    environment_vars = []
+    scripts = [
+      "setup/base_install.sh"
+    ]
+  }
+
+}

--- a/packer/base_server/base_server.pkr.hcl
+++ b/packer/base_server/base_server.pkr.hcl
@@ -26,6 +26,7 @@ build {
       "setup/weekly_update.sh",
       "templates/nginx.conf",
       "templates/uwsgi_params",
+      "templates/docker-compose.yml",
     ]
     destination = "/tmp/"
   }
@@ -45,6 +46,4 @@ build {
       "setup/base_install.sh"
     ]
   }
-
-
 }

--- a/packer/base_server/setup/base_install.sh
+++ b/packer/base_server/setup/base_install.sh
@@ -5,3 +5,8 @@ apt-get install -y nginx docker certbot
 # Setup Weekly Security Updates
 mv /tmp/weekly_update.sh /etc/cron.weekly/
 chmod 755 /etc/cron.weekly/weekly_update.sh
+
+
+cp /tmp/uwsgi_params /etc/nginx/uwsgi_params
+cp /tmp/nginx.conf /etc/nginx/sites-available/tanzawa.conf
+ln -s /etc/nginx/sites-available/tanzawa.conf /etc/nginx/sites-enabled/

--- a/packer/base_server/setup/base_install.sh
+++ b/packer/base_server/setup/base_install.sh
@@ -1,12 +1,28 @@
-apt-get update
-apt-get upgrade -y
-apt-get install -y nginx docker certbot
+# Install nginx and base packages required to install Docker
+
+apt-get update && apt-get install -y apt-utils nginx certbot apt-transport-https ca-certificates curl gnupg lsb-release python3-pip
+
+# Add Docker GPG key
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+
+# Add Docker Repo
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+
+apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io && apt-get upgrade -y
+
+# Docker compose
+pip3 install docker-compose
+ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+mv /tmp/docker-compose.yml /opt/tanzawa/
 
 # Setup Weekly Security Updates
 mv /tmp/weekly_update.sh /etc/cron.weekly/
 chmod 755 /etc/cron.weekly/weekly_update.sh
 
 
+mkdir -p /etc/nginx/sites-available/ /etc/nginx/sites-enabled
+# Move nginx config files into location
 cp /tmp/uwsgi_params /etc/nginx/uwsgi_params
 cp /tmp/nginx.conf /etc/nginx/sites-available/tanzawa.conf
 ln -s /etc/nginx/sites-available/tanzawa.conf /etc/nginx/sites-enabled/
+unlink /etc/nginx/sites-enabled/default

--- a/packer/base_server/setup/base_install.sh
+++ b/packer/base_server/setup/base_install.sh
@@ -1,3 +1,7 @@
 apt-get update
 apt-get upgrade -y
 apt-get install -y nginx docker certbot
+
+# Setup Weekly Security Updates
+mv /tmp/weekly_update.sh /etc/cron.weekly/
+chmod 755 /etc/cron.weekly/weekly_update.sh

--- a/packer/base_server/setup/base_install.sh
+++ b/packer/base_server/setup/base_install.sh
@@ -1,0 +1,3 @@
+apt-get update
+apt-get upgrade -y
+apt-get install -y nginx docker certbot

--- a/packer/base_server/setup/weekly_update.sh
+++ b/packer/base_server/setup/weekly_update.sh
@@ -1,0 +1,4 @@
+ #!/bin/bash
+apt-get update
+apt-get upgrade -y
+apt-get autoclean

--- a/packer/base_server/templates/docker-compose.yml
+++ b/packer/base_server/templates/docker-compose.yml
@@ -9,4 +9,5 @@ services:
       - /var/run/tanzawa:/var/run/tanzawa
       - /opt/tanzawa/data:/opt/tanzawa/data
     environment:
+      # TODO: Figure out the best way for Docker-compose and env files to coexist in Tanzawa
       - ENV_FILE=/opt/tanzawa/data/env

--- a/packer/base_server/templates/docker-compose.yml
+++ b/packer/base_server/templates/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+
+services:
+  web:
+    image: jamesvandyne/tanzawa
+    restart: always
+    volumes:
+      - /opt/tanzawa/staticfiles:/opt/tanzawa/static
+      - /var/run/tanzawa:/var/run/tanzawa
+      - /opt/tanzawa/data:/opt/tanzawa/data
+    environment:
+      - ENV_FILE=/opt/tanzawa/data/env

--- a/packer/base_server/templates/nginx.conf
+++ b/packer/base_server/templates/nginx.conf
@@ -7,9 +7,9 @@ upstream django {
 # configuration of the server
 server {
     # the port your site will be served on
-    listen      8000;
+    listen      80;
     # the domain name it will serve for
-    include /opt/tanzawa/server_name
+    include /opt/tanzawa/server_name;
     charset     utf-8;
 
     # max upload size

--- a/packer/base_server/templates/nginx.conf
+++ b/packer/base_server/templates/nginx.conf
@@ -1,0 +1,32 @@
+
+# the upstream component nginx needs to connect to
+upstream django {
+    server unix:///var/run/tanzawa/tanzawa.sock;
+}
+
+# configuration of the server
+server {
+    # the port your site will be served on
+    listen      8000;
+    # the domain name it will serve for
+    include /opt/tanzawa/server_name
+    charset     utf-8;
+
+    # max upload size
+    client_max_body_size 75M;
+
+    # Django media
+    location /media  {
+        alias /opt/tanzawa/media;
+    }
+
+    location /static {
+        alias /opt/tanzawa/staticfiles; # your Django project's static files - amend as required
+    }
+
+    # Finally, send all non-media requests to the Django server.
+    location / {
+        uwsgi_pass  django;
+        include     /etc/nginx/uwsgi_params; # the uwsgi_params file you installed
+    }
+}

--- a/packer/base_server/templates/uwsgi_params
+++ b/packer/base_server/templates/uwsgi_params
@@ -1,0 +1,16 @@
+uwsgi_param  QUERY_STRING       $query_string;
+uwsgi_param  REQUEST_METHOD     $request_method;
+uwsgi_param  CONTENT_TYPE       $content_type;
+uwsgi_param  CONTENT_LENGTH     $content_length;
+
+uwsgi_param  REQUEST_URI        $request_uri;
+uwsgi_param  PATH_INFO          $document_uri;
+uwsgi_param  DOCUMENT_ROOT      $document_root;
+uwsgi_param  SERVER_PROTOCOL    $server_protocol;
+uwsgi_param  REQUEST_SCHEME     $scheme;
+uwsgi_param  HTTPS              $https if_not_empty;
+
+uwsgi_param  REMOTE_ADDR        $remote_addr;
+uwsgi_param  REMOTE_PORT        $remote_port;
+uwsgi_param  SERVER_PORT        $server_port;
+uwsgi_param  SERVER_NAME        $server_name;

--- a/packer/tanzawa/README.md
+++ b/packer/tanzawa/README.md
@@ -9,6 +9,6 @@ This packer configuration builds a Docker image that is acceptable to run in pro
 |/opt/tanzawa/|Tanzawa root install|
 |/opt/tanzawa/tanzawa|Tanzawa app root|
 |/var/run/tanzawa/tanzawa.sock|uWSGI server socket|
+|/opt/tanzawa/static/|Django staticfiles|
 |/opt/tanzawa/data/db.sqlite3|Database|
-|/opt/tanzawa/data/static/|Django staticfiles|
 |/opt/tanzawa/data/media/|File uploads|

--- a/packer/tanzawa/README.md
+++ b/packer/tanzawa/README.md
@@ -1,0 +1,14 @@
+# Tanzawa uWSGI
+
+This packer configuration builds a Docker image that is acceptable to run in production environments.
+
+## Paths
+
+|Path|Description|
+|---|---|
+|/opt/tanzawa/|Tanzawa root install|
+|/opt/tanzawa/tanzawa|Tanzawa app root|
+|/var/run/tanzawa/tanzawa.sock|uWSGI server socket|
+|/opt/tanzawa/data/db.sqlite3|Database|
+|/opt/tanzawa/data/static/|Django staticfiles|
+|/opt/tanzawa/data/media/|File uploads|

--- a/packer/tanzawa/setup/base_install.sh
+++ b/packer/tanzawa/setup/base_install.sh
@@ -13,8 +13,11 @@ mkdir -p /etc/uwsgi/vassals/
 mv /tmp/uwsgi.ini /etc/uwsgi/vassals/tanzawa.ini
 
 # Setup directories
-mkdir /var/run/tanzawa/
-chown www-data:www-data /var/run/tanzawa
+mkdir -p /var/run/tanzawa/
+mkdir -p /opt/tanzawa/data/
+mkdir -p /opt/tanzawa/static/
+chown www-data:www-data /var/run/tanzawa/
+chown www-data:www-data /opt/tanzawa/data/
 
 # Install Python deps
 pip install -U pip
@@ -37,5 +40,5 @@ npm install
 npm run build
 
 # Collect static
-cd /opt/tanzawa/tanzawa/apps
-python3 manage.py collectstatic
+cd /opt/tanzawa/tanzawa/
+python3 manage.py apps/collectstatic --noinput

--- a/packer/tanzawa/setup/base_install.sh
+++ b/packer/tanzawa/setup/base_install.sh
@@ -41,4 +41,4 @@ npm run build
 
 # Collect static
 cd /opt/tanzawa/tanzawa/
-python3 manage.py apps/collectstatic --noinput
+python3 apps/manage.py collectstatic --noinput

--- a/packer/tanzawa/setup/base_install.sh
+++ b/packer/tanzawa/setup/base_install.sh
@@ -1,0 +1,41 @@
+# Install system deps
+apt-get update
+apt-get upgrade -y
+# Backend deps
+apt-get install -y spatialite-bin libsqlite3-mod-spatialite binutils libproj-dev gdal-bin nodejs npm
+
+
+# Clone latest version of Tanzawa
+git clone https://github.com/jamesvandyne/tanzawa.git /opt/tanzawa/tanzawa/
+
+# Move uwsgi configuration to the appropriate location
+mkdir -p /etc/uwsgi/vassals/
+mv /tmp/uwsgi.ini /etc/uwsgi/vassals/tanzawa.ini
+
+# Setup directories
+mkdir /var/run/tanzawa/
+chown www-data:www-data /var/run/tanzawa
+
+# Install Python deps
+pip install -U pip
+pip install uwsgi
+pip install -r /opt/tanzawa/tanzawa/requirements_dev.txt
+rm -rf /var/lib/apt/lists/*
+
+
+# Prepare env file
+# TODO: This should be fed in by Docker / not rely on the .env file
+python3 -c "import secrets; print(secrets.token_urlsafe())" | xargs -I{} -n1 echo SECRET_KEY={} >> /tmp/env
+mv /tmp/env /opt/tanzawa/tanzawa/.env
+
+
+# Install frontend deps
+cd /opt/tanzawa/tanzawa/front
+npm install
+
+# Build production assets
+npm run build
+
+# Collect static
+cd /opt/tanzawa/tanzawa/apps
+python3 manage.py collectstatic

--- a/packer/tanzawa/setup/base_install.sh
+++ b/packer/tanzawa/setup/base_install.sh
@@ -16,8 +16,10 @@ mv /tmp/uwsgi.ini /etc/uwsgi/vassals/tanzawa.ini
 mkdir -p /var/run/tanzawa/
 mkdir -p /opt/tanzawa/data/
 mkdir -p /opt/tanzawa/static/
+mkdir -p /opt/tanzawa/data/media/
 chown www-data:www-data /var/run/tanzawa/
 chown www-data:www-data /opt/tanzawa/data/
+chown www-data:www-data /opt/tanzawa/data/media/
 
 # Install Python deps
 pip install -U pip
@@ -29,7 +31,7 @@ rm -rf /var/lib/apt/lists/*
 # Prepare env file
 # TODO: This should be fed in by Docker / not rely on the .env file
 python3 -c "import secrets; print(secrets.token_urlsafe())" | xargs -I{} -n1 echo SECRET_KEY={} >> /tmp/env
-mv /tmp/env /opt/tanzawa/tanzawa/.env
+mv /tmp/env /opt/tanzawa/data/env
 
 
 # Install frontend deps

--- a/packer/tanzawa/templates/env
+++ b/packer/tanzawa/templates/env
@@ -3,7 +3,7 @@ ALLOWED_HOSTS=127.0.0.1,localhost
 SESSION_COOKIE_SECURE=True
 CSRF_COOKIE_SECURE=True
 
-DATABASE_URL=sqlite:///opt/tanzawa/data/db.sqlite3
+DATABASE_URL=sqlite:////opt/tanzawa/data/db.sqlite3
 DATABASE_ENGINE=django.contrib.gis.db.backends.spatialite
 
 

--- a/packer/tanzawa/templates/env
+++ b/packer/tanzawa/templates/env
@@ -1,0 +1,16 @@
+DEBUG=False
+ALLOWED_HOSTS=127.0.0.1,localhost
+SESSION_COOKIE_SECURE=True
+CSRF_COOKIE_SECURE=True
+
+DATABASE_URL=sqlite:///opt/tanzawa/data/db.sqlite3
+DATABASE_ENGINE=django.contrib.gis.db.backends.spatialite
+
+
+LANGUAGE_CODE=en-us
+TIME_ZONE=UTC
+
+# collect static/media in the project root.
+# production uses should probably be somewhere else
+STATIC_ROOT=/opt/tanzawa/data/static/
+MEDIA_ROOT=/opt/tanzawa/data/media/

--- a/packer/tanzawa/templates/env
+++ b/packer/tanzawa/templates/env
@@ -12,5 +12,5 @@ TIME_ZONE=UTC
 
 # collect static/media in the project root.
 # production uses should probably be somewhere else
-STATIC_ROOT=/opt/tanzawa/data/static/
+STATIC_ROOT=/opt/tanzawa/static/
 MEDIA_ROOT=/opt/tanzawa/data/media/

--- a/packer/tanzawa/templates/uwsgi.ini
+++ b/packer/tanzawa/templates/uwsgi.ini
@@ -1,0 +1,20 @@
+[uwsgi]
+
+# Django-related settings
+# the base directory (full path)
+chdir           = /opt/tanzawa/tanzawa/
+# Django's wsgi file
+module          = /opt/tanzawa/tanzawa/apps/core/wsgi.wsgi
+
+# process-related settings
+# master
+master          = true
+# maximum number of worker processes
+processes       = 10
+# the socket (use the full path to be safe
+socket = /var/run/tanzawa/tanzawa.sock
+chmod-socket = 664
+uid = www-data
+gid = www-data
+# clear environment on exit
+vacuum          = true

--- a/packer/tanzawa/templates/uwsgi.ini
+++ b/packer/tanzawa/templates/uwsgi.ini
@@ -2,9 +2,9 @@
 
 # Django-related settings
 # the base directory (full path)
-chdir           = /opt/tanzawa/tanzawa/
+chdir           = /opt/tanzawa/tanzawa/apps/
 # Django's wsgi file
-module          = /opt/tanzawa/tanzawa/apps/core/wsgi.wsgi
+module          = core.wsgi.wsgi
 
 # process-related settings
 # master

--- a/packer/tanzawa/uwsgi_tanzawa.pkr.hcl
+++ b/packer/tanzawa/uwsgi_tanzawa.pkr.hcl
@@ -35,6 +35,12 @@ build {
     ]
   }
 
-
+  post-processors {
+    post-processor "docker-tag" {
+      repository = "jamesvandyne/tanzawa"
+      tags       = ["latest"]
+    }
+    post-processor "docker-push" {}
+  }
 }
 

--- a/packer/tanzawa/uwsgi_tanzawa.pkr.hcl
+++ b/packer/tanzawa/uwsgi_tanzawa.pkr.hcl
@@ -1,0 +1,40 @@
+packer {
+  required_plugins {
+    docker = {
+      version = ">= 0.0.7"
+      source  = "github.com/hashicorp/docker"
+    }
+  }
+}
+
+
+source "docker" "ubuntu" {
+  image  = "python:3"
+  commit = true
+  changes = [
+    "ENTRYPOINT [\"uwsgi --emperor /etc/uwsgi/vassals --uid www-data --gid www-data\"]"
+  ]
+}
+
+build {
+  name = "uWSGI Tanzawa Server"
+  sources = [
+    "source.docker.ubuntu"
+  ]
+  provisioner "file" {
+    sources = [
+      "templates/uwsgi.ini",
+      "templates/env",
+    ]
+    destination = "/tmp/"
+  }
+  provisioner "shell" {
+    environment_vars = []
+    scripts = [
+      "setup/base_install.sh"
+    ]
+  }
+
+
+}
+

--- a/packer/tanzawa/uwsgi_tanzawa.pkr.hcl
+++ b/packer/tanzawa/uwsgi_tanzawa.pkr.hcl
@@ -12,7 +12,8 @@ source "docker" "ubuntu" {
   image  = "python:3"
   commit = true
   changes = [
-    "ENTRYPOINT [\"uwsgi --emperor /etc/uwsgi/vassals --uid www-data --gid www-data\"]"
+    "ENTRYPOINT [\"\"]",
+    "CMD [\"uwsgi\", \"--emperor\", \"/etc/uwsgi/vassals\", \"--uid\", \"www-data\", \"--gid\", \"www-data\"]",
   ]
 }
 


### PR DESCRIPTION
This PR adds packer configurations that will allow us to:

* Build a server image that when started runs Tanzawa inside of a docker container
* Keeps the system relatively secure (auto-updates)

There's two main parts:

1. Packer script to setup the base server
2. Dockerfile for Tanzawa running in a production-ready state on uWSGI

Provisioning should be able to take the domain name that the server will run on to allow configuration of `certbot` and the django `ALLOWED_HOSTS` environment variables.