### PR TITLE
Fix tailwind glob to find deeper nested forms

### DIFF
--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -2,6 +2,7 @@ module.exports = {
   content: [
      '../apps/**/*.html',
       '../apps/**/forms.py',
+    '../apps/**/forms/**/*.py',
       'src/**/*.js',
    ],
   theme: {

--- a/static/tailwind/style.css
+++ b/static/tailwind/style.css
@@ -1,5 +1,5 @@
 /*
-! tailwindcss v3.0.12 | MIT License | https://tailwindcss.com
+! tailwindcss v3.0.24 | MIT License | https://tailwindcss.com
 *//*
 1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
 2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
@@ -570,6 +570,9 @@ Ensure the default browser behavior of the `hidden` attribute.
 }
 .flex {
   display: flex;
+}
+.inline-flex {
+  display: inline-flex;
 }
 .table {
   display: table;


### PR DESCRIPTION
When layerizing, the streams component became deeper nested than the existing glob afforded. Add another glob to allow matching not just `forms.py`, but also `form` packages.