### PR TITLE
Remove erroneous name attribute on publish button

### DIFF
--- a/apps/templates/entry/note/_quick_form.html
+++ b/apps/templates/entry/note/_quick_form.html
@@ -51,6 +51,6 @@
         {% include "entry/fragments/syndication_form.html" with open="closed" %}
     </div>
     <div class="mt-2 mx-2">
-        <button class="rounded text-white bg-malachite-800 border-malachite-900 px-3 py-1 border w-full" name="m_post_status" value="published" form="entry" data-turbo="false">Publish</button>
+        <button class="rounded text-white bg-malachite-800 border-malachite-900 px-3 py-1 border w-full" form="entry" data-turbo="false">Publish</button>
     </div>
 </form>


### PR DESCRIPTION
Before all posts on mobile were always made published because there was a 'name' attribute on the publish button that shouldn't been there.