### PR TITLE
Make trip blog posts wider

### DIFF
--- a/apps/templates/public/trips/trip_detail.html
+++ b/apps/templates/public/trips/trip_detail.html
@@ -16,7 +16,7 @@
             ></div>
             {% endwith %}
         </div>
-        <div class="w-full md:w-96 md:mx-2 h-screen overflow-scroll">
+        <div class="w-full md:w-9/12 md:mx-2 h-screen overflow-scroll">
             <h1 class="text-2xl ml-2 md:ml-0">Trip to {{ t_trip.name }}</h1>
             <h2 class="help-text ml-2 md:ml-0">{{ t_trip.d_start }} ~ {{  t_trip.d_end|default_if_none:"" }}</h2>
             <p class="mx-2 md:ml-0">{{ t_trip.p_summary }}</p>


### PR DESCRIPTION
Makes the posts easier to read and the photos larger.

<img width="1373" alt="Screen Shot 2022-07-20 at 12 46 25" src="https://user-images.githubusercontent.com/154726/179892400-6ddb37ee-52c3-4ca1-8104-7a12fc152753.png">

