### PR TITLE
Blog nav

### DIFF
--- a/apps/interfaces/dashboard/urls.py
+++ b/apps/interfaces/dashboard/urls.py
@@ -13,9 +13,6 @@ urlpatterns = [
     path("", include("interfaces.dashboard.top.urls", namespace="post")),
 ]
 
-# Include any plugin urls after core urls.
-plugin_urls = [path("", include(plugin_urls)) for plugin_urls in pool.plugin_pool.urls()]
-urlpatterns.extend(plugin_urls)
 
 plugin_admin_urls = [
     path(f"plugins/{text.slugify(plugin.name)}/", include(plugin.admin_urls))

--- a/apps/interfaces/public/home/urls.py
+++ b/apps/interfaces/public/home/urls.py
@@ -3,5 +3,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path("blog/", views.BlogListView.as_view(), name="blog"),
     path("", views.HomeView.as_view(), name="home"),
 ]

--- a/apps/interfaces/public/urls.py
+++ b/apps/interfaces/public/urls.py
@@ -1,6 +1,11 @@
 from django.urls import include, path
 
+from data.plugins import pool
+
 app_name = "public"
+
+plugin_urls = [path("", include(plugin_urls)) for plugin_urls in pool.plugin_pool.urls()]
+
 
 urlpatterns = [
     path("", include("interfaces.public.feeds.urls")),
@@ -40,5 +45,6 @@ urlpatterns = [
         "",
         include("interfaces.public.indieweb.urls"),
     ),
+    *plugin_urls,
     path("", include("interfaces.public.streams.urls")),
 ]

--- a/apps/tanzawa_plugin/now/templates/now/fragments/submit.html
+++ b/apps/tanzawa_plugin/now/templates/now/fragments/submit.html
@@ -1,9 +1,9 @@
 <section class="mb-2">
     <div class="mb-1">
-        <button class="rounded text-white bg-malachite-800 border-malachite-900 px-3 py-1 border" value="published" form="now" data-turbo="false">Save </button>
+        <button class="rounded text-white bg-malachite-800 border-malachite-900 px-3 py-1 border" value="published" form="now" data-turbo="false">Save</button>
     </div>
 </section>
 
 <section>
-    <a href="{% url "plugin_now:now" %}" class="ml-auto btn-link" target="_new">View on site</a>
+    <a href="{% url "public:now" %}" class="ml-auto btn-link" target="_new">View on site</a>
 </section>

--- a/apps/tanzawa_plugin/now/templates/now/navigation.html
+++ b/apps/tanzawa_plugin/now/templates/now/navigation.html
@@ -1,10 +1,10 @@
 {% if render_location == "NAV.TOP" %}
-<a href="{% url "plugin_now:now" %}" class="ml-2 leading-8 hidden md:inline-block{% if nav == "now" %} border-b-4 border-secondary{% endif %}">
+<a href="{% url "public:now" %}" class="ml-2 leading-8 hidden md:inline-block{% if nav == "now" %} border-b-4 border-secondary{% endif %}">
     <span class="mr-1">👉</span>Now
 </a>
 {% elif render_location == "NAV.TOP.MOBILE" %}
     <li class="{% if 'nav' == now %}border-l-4 border-secondary{% endif %} p-1 mb-2">
-        <a href="{% url "plugin_now:now" %}" class="w-full inline-block">
+        <a href="{% url "public:now" %}" class="w-full inline-block">
             <span class="mr-1">👉</span>Now
         </a>
     </li>

--- a/apps/tanzawa_plugin/now/urls.py
+++ b/apps/tanzawa_plugin/now/urls.py
@@ -2,8 +2,6 @@ from django.urls import path
 
 from . import views
 
-app_name = "plugin_now"
-
 urlpatterns = [
     path("now/", views.PublicViewNow.as_view(), name="now"),
 ]

--- a/apps/templates/base_public.html
+++ b/apps/templates/base_public.html
@@ -46,6 +46,7 @@
                     {% if centered_nav %}<div class="mx-auto">{% endif %}
                     <a href="{% url "public:trips" %}" class="{% if 'trips' in selected %}border-b-4 border-secondary{% endif %} ml-2 leading-8 hidden md:inline-block"><span class="mr-1">✈️</span><span>Trips</span></a>
                     <a href="{% url "public:cluster_map" %}" class="{% if 'maps' in selected %}border-b-4 border-secondary{% endif %} ml-2 leading-8 hidden md:inline-block"><span class="mr-1">🗺️</span><span>Maps</span></a>
+                    <a href="{% url "public:blog" %}" class="{% if 'blog' in selected %}border-b-4 border-secondary{% endif %} ml-2 leading-8 hidden md:inline-block"><span class="mr-1">✏️️</span><span>Blog</span></a>
 
                     {% for plugin in request.plugin_pool.enabled_plugins %}
                         {% if plugin.has_public_top_nav %}
@@ -68,6 +69,7 @@
                     <li class="{% if 'home' in selected %}border-l-4 border-secondary{% endif %} p-1 mb-2"><a href="{% url "public:home" %}" class="w-full inline-block"><span class="mr-1">🏡</span><span>Home</span></a></li>
                     <li class="{% if 'trips' in selected %}border-l-4 border-secondary{% endif %} p-1 mb-2"><a href="{% url "public:trips" %}" class="w-full inline-block"><span class="mr-1">✈️</span><span>Trips</span></a></li>
                     <li class="{% if 'maps' in selected %}border-l-4 border-secondary{% endif %} p-1 mb-2"><a href="{% url "public:cluster_map" %}" class="w-full inline-block"><span class="mr-1">🗺️</span><span>Maps</span></a></li>
+                    <li class="{% if 'blog' in selected %}border-l-4 border-secondary{% endif %} p-1 mb-2"><a href="{% url "public:blog" %}" class="w-full inline-block"><span class="mr-1">✏️</span><span>Blog</span></a></li>
                     {% for plugin in request.plugin_pool.enabled_plugins %}
                         {% if plugin.has_public_top_nav %}
                             {% render_plugin plugin.identifier "NAV.TOP.MOBILE" %}


### PR DESCRIPTION
This PR adds `/blog/` to the navigation, which links to the old default view of Tanzawa, which was a list of blog posts.

It also fixes the `/now/` page URL by moving plugin urls to the public url tree, instead of the admin url tree.