### PR TITLE
Add gallery to homepage

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,3 +20,5 @@ MEDIA_ROOT=./micropub_media/
 
 # macOS
 # SPATIALITE_LIBRARY_PATH=/usr/local/lib/mod_spatialite.dylib
+
+HIGHLIGHT_STREAM_SLUG=the-week

--- a/apps/application/entry/_open_graph.py
+++ b/apps/application/entry/_open_graph.py
@@ -3,7 +3,7 @@ from dataclasses import asdict, dataclass, field
 from meta import views as meta_views
 
 from data.entry import models
-from domain.files import images
+from domain.files import queries
 
 
 @dataclass
@@ -38,7 +38,7 @@ def _get_image(entry: models.TEntry, request) -> OpenGraphImage | None:
     if entry.is_checkin or entry.is_note or entry.is_article:
         # Notes and checkins might have an image or more associated with them.
         # If so, use the first image for the open graph meta
-        image = images.get_representative_image(post=entry.t_post)
+        image = queries.get_representative_image(post=entry.t_post)
         if image:
             formatted_image = image.ref_t_formatted_image.first()
             if formatted_image:

--- a/apps/core/settings.py
+++ b/apps/core/settings.py
@@ -212,6 +212,9 @@ LOGIN_REDIRECT_URL = "post:dashboard"
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 
+# Homepage Settings
+HIGHLIGHT_STREAM_SLUG: str | None = env.str("HIGHLIGHT_STREAM_SLUG", default=None)
+
 PLUGINS = env.list("PLUGINS", default=[])
 
 INSTALLED_APPS.extend(PLUGINS)

--- a/apps/domain/files/__init__.py
+++ b/apps/domain/files/__init__.py
@@ -1,3 +1,0 @@
-from . import _images as images
-
-__all__ = ["images"]

--- a/apps/domain/files/_images.py
+++ b/apps/domain/files/_images.py
@@ -1,6 +1,0 @@
-from data.files import models
-from data.post import models as post_models
-
-
-def get_representative_image(post: post_models.TPost) -> models.TFile | None:
-    return post.files.filter(mime_type__startswith="image").first()

--- a/apps/domain/files/queries.py
+++ b/apps/domain/files/queries.py
@@ -1,0 +1,15 @@
+from data.files import models as file_models
+from django.db.models import QuerySet
+from data.indieweb.constants import MPostStatuses
+
+from core.constants import Visibility
+
+
+def get_public_photos(limit: int = 10) -> QuerySet[file_models.TFile]:
+    qs = (
+        file_models.TFile.objects.filter(mime_type__startswith="image")
+        .filter(posts__m_post_status__key=MPostStatuses.published)
+        .exclude(posts__visibility=Visibility.UNLISTED)
+        .order_by("-posts__dt_published")
+    )
+    return qs[:limit]

--- a/apps/domain/files/queries.py
+++ b/apps/domain/files/queries.py
@@ -1,11 +1,15 @@
-from data.files import models as file_models
 from django.db.models import QuerySet
-from data.indieweb.constants import MPostStatuses
 
 from core.constants import Visibility
+from data.files import models as file_models
+from data.indieweb.constants import MPostStatuses
+from data.post import models as post_models
 
 
 def get_public_photos(limit: int = 10) -> QuerySet[file_models.TFile]:
+    """
+    Return a queryset of public photos.
+    """
     qs = (
         file_models.TFile.objects.filter(mime_type__startswith="image")
         .filter(posts__m_post_status__key=MPostStatuses.published)
@@ -13,3 +17,10 @@ def get_public_photos(limit: int = 10) -> QuerySet[file_models.TFile]:
         .order_by("-posts__dt_published")
     )
     return qs[:limit]
+
+
+def get_representative_image(post: post_models.TPost) -> file_models.TFile | None:
+    """
+    Return the first image in a post that's used as the representative image.
+    """
+    return post.files.filter(mime_type__startswith="image").first()

--- a/apps/interfaces/public/home/views.py
+++ b/apps/interfaces/public/home/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db.models import Count, Q
 from django.views.generic import ListView, TemplateView
 
@@ -51,12 +52,12 @@ class BlogListView(ListView):
 class HomeView(TemplateView):
     template_name = "public/home.html"
     paginate_by = 5
-    # TODO: Make this slug dynamic / settable in the db.
-    stream_name = "the-week"
+    stream_name: str | None = None
     stream: MStream | None
 
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
+        self.stream_name = settings.HIGHLIGHT_STREAM_SLUG
         try:
             self.stream = MStream.objects.get(slug=self.stream_name)
         except MStream.DoesNotExist:

--- a/apps/interfaces/public/home/views.py
+++ b/apps/interfaces/public/home/views.py
@@ -6,6 +6,7 @@ from data.entry.models import TEntry
 from data.indieweb.constants import MPostKinds, MPostStatuses
 from data.post.models import MPostKind
 from data.streams.models import MStream
+from domain.files import queries as file_queries
 from domain.posts import queries as post_queries
 
 
@@ -88,6 +89,7 @@ class HomeView(TemplateView):
                         ["text-lg", "text-md", "text-sm", "text-xs"],
                     ),
                 },
+                "photo_gallery": file_queries.get_public_photos(limit=10),
             }
         )
         return context

--- a/apps/templates/public/home.html
+++ b/apps/templates/public/home.html
@@ -13,7 +13,7 @@
     <div class="w-full md:flex flex-col p-2">
 
         <div class="md:max-w-prose mx-auto">
-        <div class="md:flex">
+            <div class="md:flex">
             <div>
                 <h1>💬 Status</h1>
                 <ul class="mt-2">
@@ -34,8 +34,7 @@
             </div>
 
         </div>
-        <div class="mt-2 md:flex md:mt-8">
-
+            <div class="mt-2 md:flex md:mt-8">
             <div class="md:flex flex-col flex-grow">
                 {% if highlight_kind.kind %}
                 <div class="mb-2 md:mb-4">
@@ -85,6 +84,17 @@
             </div>
 
         </div>
+            <div class="mt-2 md:mt-8">
+                <h1>📸 Photos</h1>
+                <div class="mt-2 grid grid-cols-3 gap-2 md:grid-cols-5">
+                    {% for photo in photo_gallery %}
+                        <picture>
+                            <source srcset="{% url 'public:get_media' photo.uuid %}?s=256&f=image/webp 2x" type="image/webp"/>
+                            <img src="{% url 'public:get_media' photo.uuid %}?s=128&f=image/webp" loading="lazy"  class="h-24 w-24 object-cover"/>
+                        </picture>
+                    {% endfor %}
+                </div>
+            </div>
         </div>
 
     </div>

--- a/static/tailwind/style.css
+++ b/static/tailwind/style.css
@@ -610,6 +610,9 @@ Ensure the default browser behavior of the `hidden` attribute.
 .h-80 {
   height: 20rem;
 }
+.h-24 {
+  height: 6rem;
+}
 .h-12 {
   height: 3rem;
 }
@@ -657,6 +660,9 @@ Ensure the default browser behavior of the `hidden` attribute.
 }
 .w-80 {
   width: 20rem;
+}
+.w-24 {
+  width: 6rem;
 }
 .w-10 {
   width: 2.5rem;
@@ -1489,6 +1495,10 @@ main.content blockquote {
 
   .md\:grid-cols-4 {
     grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .md\:grid-cols-5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 
   .md\:grid-cols-3 {


### PR DESCRIPTION
This PR adds a small gallery to the homepage so photos from recent checkins etc... are easily discoverable. It also:

* Sneaks in a a small refactor, moving an image query to a queries module
* Allows the highlighted stream to be configurable by the `HIGHLIGHT_STREAM_SLUG` in the django settings / environment variable / .env file. e.g. `HIGHLIGHT_STREAM_SLUG=the-week`.

<img width="690" alt="image" src="https://user-images.githubusercontent.com/154726/215310684-f00b72f2-1f8a-4add-a97a-e1e0e6dab94a.png">
