### PR TITLE
Upgrade to Django 4.2

### DIFF
--- a/apps/application/indieweb/extract.py
+++ b/apps/application/indieweb/extract.py
@@ -35,7 +35,6 @@ def extract_description(soup: BeautifulSoup) -> str:
 
 
 def extract_reply_details_from_url(url: str) -> LinkedPage | None:
-
     # Specify a custom User Agent as some sites prevent scraping by blocking the default requests UA.
     response = requests.get(url, headers={"User-Agent": "Tanzawa"})
     if response.status_code != 200:

--- a/apps/application/indieweb/webmentions.py
+++ b/apps/application/indieweb/webmentions.py
@@ -93,7 +93,6 @@ def send_webmention(request, t_post: TPost, e_content: str) -> list[indieweb_mod
 
         wm_status, wm_url = ronkyuu.discoverEndpoint(target, test_urls=False)
         if wm_url is not None and wm_status == 200:
-
             try:
                 t_webmention_send = t_post.ref_t_webmention_send.get(target=target)
             except indieweb_models.TWebmentionSend.DoesNotExist:

--- a/apps/core/settings.py
+++ b/apps/core/settings.py
@@ -27,6 +27,7 @@ env.read_envfile(path=os.environ.get("ENV_FILE"))
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
+
 # SECURITY WARNING: keep the secret key used in production secret!
 def get_secret_key() -> str:
     secret_key = env.str("SECRET_KEY", default="")

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -36,7 +36,6 @@ def handle404(request, exception):
 @require_GET
 @cache_control(max_age=60 * 60 * 24, immutable=True, public=True)  # one day
 def favicon(request: HttpRequest) -> HttpResponse:
-
     return HttpResponse(
         (
             '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">'

--- a/apps/data/entry/migrations/0001_initial.py
+++ b/apps/data/entry/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/apps/data/entry/migrations/0002_treply.py
+++ b/apps/data/entry/migrations/0002_treply.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("entry", "0001_initial"),
     ]

--- a/apps/data/entry/migrations/0003_tbookmark.py
+++ b/apps/data/entry/migrations/0003_tbookmark.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("entry", "0002_treply"),
     ]

--- a/apps/data/entry/migrations/0004_tcheckin_tlocation.py
+++ b/apps/data/entry/migrations/0004_tcheckin_tlocation.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("entry", "0003_tbookmark"),
     ]

--- a/apps/data/entry/migrations/0005_tsyndication.py
+++ b/apps/data/entry/migrations/0005_tsyndication.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("entry", "0004_tcheckin_tlocation"),
     ]

--- a/apps/data/entry/migrations/0006_tentry_t_post_1x1.py
+++ b/apps/data/entry/migrations/0006_tentry_t_post_1x1.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("post", "0006_tpost_streams"),
         ("entry", "0005_tsyndication"),

--- a/apps/data/entry/migrations/0007_update_verbose_names.py
+++ b/apps/data/entry/migrations/0007_update_verbose_names.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("entry", "0006_tentry_t_post_1x1"),
     ]

--- a/apps/data/entry/migrations/0008_fix_location_coordinates.py
+++ b/apps/data/entry/migrations/0008_fix_location_coordinates.py
@@ -17,7 +17,6 @@ def fix_location_point(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("entry", "0007_update_verbose_names"),
     ]

--- a/apps/data/entry/models.py
+++ b/apps/data/entry/models.py
@@ -20,7 +20,6 @@ class TEntryManager(models.Manager):
 
 
 class TEntry(TimestampModel):
-
     t_post = models.OneToOneField("post.TPost", on_delete=models.CASCADE, related_name="ref_t_entry")
 
     p_name = models.CharField(max_length=255, blank=True, default="")
@@ -70,7 +69,6 @@ class TEntry(TimestampModel):
 
 
 class TReply(TimestampModel):
-
     t_entry = models.OneToOneField(TEntry, on_delete=models.CASCADE, related_name="t_reply")
     u_in_reply_to = models.URLField()
     title = models.CharField(max_length=128, blank=True, default="")
@@ -110,7 +108,6 @@ class TReply(TimestampModel):
 
 
 class TBookmark(TimestampModel):
-
     t_entry = models.OneToOneField(TEntry, on_delete=models.CASCADE, related_name="t_bookmark")
     u_bookmark_of = models.URLField()
     title = models.CharField(max_length=128, blank=True, default="")
@@ -140,7 +137,6 @@ class TBookmark(TimestampModel):
     def update(
         self, u_bookmark_of: str, title: str, quote: str, author: str, author_url: str, author_photo: str
     ) -> None:
-
         self.u_bookmark_of = u_bookmark_of
         self.title = title
         self.quote = quote

--- a/apps/data/files/migrations/0001_initial.py
+++ b/apps/data/files/migrations/0001_initial.py
@@ -8,7 +8,6 @@ import data.files._upload
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/apps/data/files/migrations/0002_add_t_formatted_image.py
+++ b/apps/data/files/migrations/0002_add_t_formatted_image.py
@@ -7,7 +7,6 @@ import data.files._upload
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("files", "0001_initial"),
     ]

--- a/apps/data/files/migrations/0003_tfile_exif.py
+++ b/apps/data/files/migrations/0003_tfile_exif.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("files", "0002_add_t_formatted_image"),
     ]

--- a/apps/data/files/migrations/0004_formatted_image_width_height_unique.py
+++ b/apps/data/files/migrations/0004_formatted_image_width_height_unique.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("files", "0003_tfile_exif"),
     ]

--- a/apps/data/files/migrations/0005_update_verbose_names.py
+++ b/apps/data/files/migrations/0005_update_verbose_names.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("files", "0004_formatted_image_width_height_unique"),
     ]

--- a/apps/data/files/models.py
+++ b/apps/data/files/models.py
@@ -33,7 +33,6 @@ class TFile(TimestampModel):
 
 
 class TFilePost(TimestampModel):
-
     t_file = models.ForeignKey(TFile, on_delete=models.CASCADE)
     t_post = models.ForeignKey("post.TPost", on_delete=models.CASCADE)
 

--- a/apps/data/indieweb/handlers.py
+++ b/apps/data/indieweb/handlers.py
@@ -11,5 +11,4 @@ logger = logging.getLogger(__name__)
 
 @receiver(post_save, sender=webmention_models.WebMentionResponse)
 def create_t_webmention(sender, instance, created, raw, using, update_fields, **kwargs):
-
     webmentions.create_moderation_record_for_webmention(instance)

--- a/apps/data/indieweb/migrations/0001_initial.py
+++ b/apps/data/indieweb/migrations/0001_initial.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/apps/data/indieweb/migrations/0002_twebmentionsend.py
+++ b/apps/data/indieweb/migrations/0002_twebmentionsend.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("post", "0005_rename_published_updated_columns"),
         ("indieweb", "0001_initial"),

--- a/apps/data/indieweb/migrations/0003_ttoken.py
+++ b/apps/data/indieweb/migrations/0003_ttoken.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("indieweb", "0002_twebmentionsend"),

--- a/apps/data/indieweb/migrations/0004_add_default_scopes.py
+++ b/apps/data/indieweb/migrations/0004_add_default_scopes.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 def register_micropub_scopes(apps, schema):
-
     MMicropubScope = apps.get_model("indieweb", "MMicropubScope")
 
     MMicropubScope.objects.get_or_create(key="create", name="Create")
@@ -15,7 +14,6 @@ def register_micropub_scopes(apps, schema):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("indieweb", "0003_ttoken"),
     ]

--- a/apps/data/indieweb/migrations/0005_update_verbose_names.py
+++ b/apps/data/indieweb/migrations/0005_update_verbose_names.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("indieweb", "0004_add_default_scopes"),
     ]

--- a/apps/data/indieweb/migrations/0006_trelme.py
+++ b/apps/data/indieweb/migrations/0006_trelme.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("indieweb", "0005_update_verbose_names"),

--- a/apps/data/indieweb/migrations/0007_ttoken_exchanged_at.py
+++ b/apps/data/indieweb/migrations/0007_ttoken_exchanged_at.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("indieweb", "0006_trelme"),
     ]

--- a/apps/data/indieweb/models/_m_micropub_scope.py
+++ b/apps/data/indieweb/models/_m_micropub_scope.py
@@ -4,7 +4,6 @@ from core.models import TimestampModel
 
 
 class MMicropubScope(TimestampModel):
-
     key = models.CharField(max_length=12, unique=True)
     name = models.CharField(max_length=16)
 

--- a/apps/data/indieweb/models/_t_rel_me.py
+++ b/apps/data/indieweb/models/_t_rel_me.py
@@ -5,7 +5,6 @@ from core.models import TimestampModel
 
 
 class TRelMe(TimestampModel):
-
     user = models.ForeignKey(get_user_model(), on_delete=models.CASCADE, related_name="relme")
     url = models.URLField(
         unique=True, help_text="URL to your profile on other sites. Email adddress should start with mailto."

--- a/apps/data/indieweb/models/_t_webmention.py
+++ b/apps/data/indieweb/models/_t_webmention.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
 
 
 class TWebmention(TimestampModel):
-
     t_webmention_response = models.ForeignKey(
         WebMentionResponse, related_name="ref_t_webmention", on_delete=models.CASCADE
     )

--- a/apps/data/plugins/migrations/0001_initial.py
+++ b/apps/data/plugins/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/apps/data/plugins/models.py
+++ b/apps/data/plugins/models.py
@@ -13,7 +13,6 @@ class MPluginManager(models.Manager):
 
 
 class MPlugin(TimestampModel):
-
     identifier = models.CharField(max_length=255, unique=True)
     enabled = models.BooleanField(default=False)
 

--- a/apps/data/plugins/pool.py
+++ b/apps/data/plugins/pool.py
@@ -29,7 +29,6 @@ class PluginPool:
             del self.__dict__["registered_plugins"]
 
     def discover_plugins(self) -> None:
-
         if self.discovered:
             return
         # Load our plugins module so we can discover our plugins automatically.

--- a/apps/data/post/migrations/0001_initial.py
+++ b/apps/data/post/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/apps/data/post/migrations/0002_register_status_kinds.py
+++ b/apps/data/post/migrations/0002_register_status_kinds.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 def register_default_post_statuses(apps, schema):
-
     MPostStatus = apps.get_model("post", "MPostStatus")
 
     MPostStatus.objects.get_or_create(key="published", name="Published")
@@ -12,7 +11,6 @@ def register_default_post_statuses(apps, schema):
 
 
 def register_default_post_kinds(apps, schema):
-
     MPostKind = apps.get_model("post", "MPostKind")
 
     MPostKind.objects.get_or_create(key="article", name="Article")
@@ -24,7 +22,6 @@ def register_default_post_kinds(apps, schema):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("post", "0001_initial"),
     ]

--- a/apps/data/post/migrations/0003_tpost_files.py
+++ b/apps/data/post/migrations/0003_tpost_files.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("files", "0001_initial"),
         ("post", "0002_register_status_kinds"),

--- a/apps/data/post/migrations/0004_tpost_uuid.py
+++ b/apps/data/post/migrations/0004_tpost_uuid.py
@@ -13,7 +13,6 @@ def create_uuid(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("post", "0003_tpost_files"),
     ]

--- a/apps/data/post/migrations/0005_rename_published_updated_columns.py
+++ b/apps/data/post/migrations/0005_rename_published_updated_columns.py
@@ -13,7 +13,6 @@ def set_published_date(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("post", "0004_tpost_uuid"),
     ]

--- a/apps/data/post/migrations/0006_tpost_streams.py
+++ b/apps/data/post/migrations/0006_tpost_streams.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("streams", "0001_initial"),
         ("post", "0005_rename_published_updated_columns"),

--- a/apps/data/post/migrations/0007_update_verbose_names.py
+++ b/apps/data/post/migrations/0007_update_verbose_names.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("post", "0006_tpost_streams"),
     ]

--- a/apps/data/post/migrations/0008_tpost_visibility.py
+++ b/apps/data/post/migrations/0008_tpost_visibility.py
@@ -6,7 +6,6 @@ import core.constants
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("post", "0007_update_verbose_names"),
     ]

--- a/apps/data/post/migrations/0009_tpost_trips.py
+++ b/apps/data/post/migrations/0009_tpost_trips.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("trips", "0001_initial"),
         ("post", "0008_tpost_visibility"),

--- a/apps/data/post/models.py
+++ b/apps/data/post/models.py
@@ -14,7 +14,6 @@ from data.indieweb.constants import MPostKinds, MPostStatuses
 
 
 class MPostStatus(TimestampModel):
-
     key = models.CharField(max_length=16, unique=True)
     name = models.CharField(max_length=16)
 
@@ -28,7 +27,6 @@ class MPostStatus(TimestampModel):
 
 
 class MPostKind(TimestampModel):
-
     key = models.CharField(max_length=16, unique=True)
     name = models.CharField(max_length=16)
 
@@ -74,7 +72,6 @@ class TPostManager(models.Manager):
 
 
 class TPost(TimestampModel):
-
     m_post_status = models.ForeignKey(MPostStatus, on_delete=models.CASCADE)
     m_post_kind = models.ForeignKey(MPostKind, on_delete=models.CASCADE)
     uuid = models.UUIDField(default=uuid.uuid4)

--- a/apps/data/settings/migrations/0001_initial.py
+++ b/apps/data/settings/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/apps/data/settings/migrations/0002_update_verbose_names.py
+++ b/apps/data/settings/migrations/0002_update_verbose_names.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("settings", "0001_initial"),
     ]

--- a/apps/data/settings/migrations/0003_msitesettings_theme.py
+++ b/apps/data/settings/migrations/0003_msitesettings_theme.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("settings", "0002_update_verbose_names"),
     ]

--- a/apps/data/settings/migrations/0004_icon_footer_snippet.py
+++ b/apps/data/settings/migrations/0004_icon_footer_snippet.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("settings", "0003_msitesettings_theme"),
     ]

--- a/apps/data/settings/migrations/0005_msitesettings_active_trip.py
+++ b/apps/data/settings/migrations/0005_msitesettings_active_trip.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("trips", "0002_auto_20220404_0621"),
         ("settings", "0004_icon_footer_snippet"),

--- a/apps/data/settings/models.py
+++ b/apps/data/settings/models.py
@@ -4,7 +4,6 @@ from core.models import TimestampModel
 
 
 class MSiteSettings(TimestampModel):
-
     title = models.CharField(max_length=128, default="Tanzawa", blank=True)
     subtitle = models.CharField(max_length=128, default="", blank=True)
     theme = models.CharField(max_length=128, default="", blank=True)

--- a/apps/data/streams/migrations/0001_initial.py
+++ b/apps/data/streams/migrations/0001_initial.py
@@ -7,7 +7,6 @@ import core.constants
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/apps/data/streams/migrations/0002_add_default_streams.py
+++ b/apps/data/streams/migrations/0002_add_default_streams.py
@@ -15,7 +15,6 @@ def add_default_streams(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("streams", "0001_initial"),
     ]

--- a/apps/data/streams/migrations/0003_alter_mstream_icon.py
+++ b/apps/data/streams/migrations/0003_alter_mstream_icon.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("streams", "0002_add_default_streams"),
     ]

--- a/apps/data/streams/migrations/0004_update_verbose_names.py
+++ b/apps/data/streams/migrations/0004_update_verbose_names.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("streams", "0003_alter_mstream_icon"),
     ]

--- a/apps/data/streams/models.py
+++ b/apps/data/streams/models.py
@@ -13,7 +13,6 @@ class MStreamManager(models.Manager):
 
 
 class MStream(TimestampModel):
-
     icon = models.CharField(max_length=2, help_text="Select an emoji")
     name = models.CharField(max_length=32)
     slug = models.SlugField(unique=True)
@@ -32,7 +31,6 @@ class MStream(TimestampModel):
 
 
 class TStreamPost(TimestampModel):
-
     m_stream = models.ForeignKey(MStream, on_delete=models.CASCADE)
     t_post = models.ForeignKey("post.TPost", on_delete=models.CASCADE)
 

--- a/apps/data/trips/migrations/0001_initial.py
+++ b/apps/data/trips/migrations/0001_initial.py
@@ -11,7 +11,6 @@ import core.constants
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/apps/data/trips/migrations/0002_auto_20220404_0621.py
+++ b/apps/data/trips/migrations/0002_auto_20220404_0621.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("trips", "0001_initial"),
     ]

--- a/apps/data/wordpress/migrations/0001_initial.py
+++ b/apps/data/wordpress/migrations/0001_initial.py
@@ -9,7 +9,6 @@ import data.wordpress.upload
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/apps/data/wordpress/migrations/0002_add_twordpresspost_path.py
+++ b/apps/data/wordpress/migrations/0002_add_twordpresspost_path.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("wordpress", "0001_initial"),
     ]

--- a/apps/data/wordpress/migrations/0003_twordpressattachment_link.py
+++ b/apps/data/wordpress/migrations/0003_twordpressattachment_link.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("wordpress", "0002_add_twordpresspost_path"),
     ]

--- a/apps/data/wordpress/migrations/0004_fk_set_null.py
+++ b/apps/data/wordpress/migrations/0004_fk_set_null.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("files", "0003_tfile_exif"),
         ("post", "0006_tpost_streams"),

--- a/apps/data/wordpress/migrations/0005_update_verbose_names.py
+++ b/apps/data/wordpress/migrations/0005_update_verbose_names.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("wordpress", "0004_fk_set_null"),
     ]

--- a/apps/domain/indieweb/indieauth/operations.py
+++ b/apps/domain/indieweb/indieauth/operations.py
@@ -40,7 +40,6 @@ def extract_auth_token_from_request(request) -> str:
 
 @transaction.atomic
 def create_token_for_user(*, user, client_id: str, scope: Iterable[models.MMicropubScope]) -> models.TToken:
-
     t_token = models.TToken.new(
         user=user,
         auth_token=queries.get_new_token(),

--- a/apps/interfaces/common/templatetags/indieweb.py
+++ b/apps/interfaces/common/templatetags/indieweb.py
@@ -13,5 +13,4 @@ class RenderRelme(template.Node):
 
 @register.tag(name="render_relme")
 def do_render_relme(parser, token):
-
     return RenderRelme()

--- a/apps/interfaces/common/templatetags/plugins.py
+++ b/apps/interfaces/common/templatetags/plugins.py
@@ -25,7 +25,6 @@ class RenderPlugin(template.Node):
 
 @register.tag(name="render_plugin")
 def do_render_plugin(parser, token):
-
     try:
         # split_contents() knows not to split quoted strings.
         tag_name, plugin_identifier, render_location = token.split_contents()

--- a/apps/interfaces/dashboard/entry/forms.py
+++ b/apps/interfaces/dashboard/entry/forms.py
@@ -338,7 +338,6 @@ class TLocationModelForm(forms.ModelForm):
 
 
 class TCheckinModelForm(forms.ModelForm):
-
     name = TCharField(label="Where did you go?")
     url = forms.URLField(
         label="What's its url?",

--- a/apps/interfaces/dashboard/indieweb/forms.py
+++ b/apps/interfaces/dashboard/indieweb/forms.py
@@ -4,12 +4,10 @@ from data.indieweb.models import MMicropubScope
 
 
 class MMicropubCheckboxWidget(forms.CheckboxSelectMultiple):
-
     option_template_name = "indieweb/fragments/micropub_checkbox_option.html"
 
 
 class IndieAuthAuthorizationForm(forms.Form):
-
     client_id = forms.URLField(widget=forms.HiddenInput)
     redirect_uri = forms.URLField(widget=forms.HiddenInput)
     state = forms.CharField(widget=forms.HiddenInput)

--- a/apps/interfaces/dashboard/indieweb/serializers.py
+++ b/apps/interfaces/dashboard/indieweb/serializers.py
@@ -7,7 +7,6 @@ ResponseTypeChoices = [("id", "id"), ("code", "id+authorization")]
 
 
 class IndieAuthAuthorizationSerializer(serializers.Serializer):
-
     me = serializers.URLField(required=False)
     client_id = serializers.URLField(required=True)
     redirect_uri = serializers.URLField(required=True)

--- a/apps/interfaces/dashboard/plugins/views.py
+++ b/apps/interfaces/dashboard/plugins/views.py
@@ -8,7 +8,6 @@ from data.plugins import activation, pool
 
 @auth_decorators.login_required
 def plugin_list(request):
-
     return render(
         request,
         "plugins/plugin_list.html",

--- a/apps/interfaces/dashboard/wordpress/forms.py
+++ b/apps/interfaces/dashboard/wordpress/forms.py
@@ -115,7 +115,6 @@ class WordpressUploadForm(forms.ModelForm):
 
 
 class TCategoryModelForm(forms.ModelForm):
-
     t_stream = StreamModelChoiceField(MStream.objects, label="", empty_label="Skip", required=False)
 
     class Meta:

--- a/apps/interfaces/dashboard/wordpress/views.py
+++ b/apps/interfaces/dashboard/wordpress/views.py
@@ -53,7 +53,6 @@ logger = logging.getLogger(__name__)
 
 @method_decorator(login_required, name="dispatch")
 class TWordpressListView(ListView):
-
     model = TWordpress
     allow_empty = False
 
@@ -164,7 +163,6 @@ def import_posts(request, pk):
 
 
 def import_post(request, t_wordpress_post: TWordpressPost, soup: BeautifulSoup):  # noqa: C901  too complex (32)!
-
     guid = soup.find("guid", text=t_wordpress_post.guid)
     t_post = t_wordpress_post.t_post
     if t_post:
@@ -173,7 +171,6 @@ def import_post(request, t_wordpress_post: TWordpressPost, soup: BeautifulSoup):
         t_entry = None
 
     if not guid:
-
         raise forms.ValidationError("Guid doesn't exist in export file")
     item = guid.parent
     logging.info("Processing %s", guid)
@@ -272,7 +269,6 @@ def import_post(request, t_wordpress_post: TWordpressPost, soup: BeautifulSoup):
     if t_wordpress_post.path != "/":
         for attachment in TWordpressAttachment.objects.filter(link__contains=t_wordpress_post.path):
             if attachment.t_file:
-
                 if str(attachment.t_file.uuid) in form_data["e_content"]:
                     # File was already inserted into the post in the image rewrite step above. Skip.
                     continue

--- a/apps/interfaces/public/indieweb/serializers.py
+++ b/apps/interfaces/public/indieweb/serializers.py
@@ -96,7 +96,6 @@ class EContentSerializer(serializers.Serializer):
 
 
 class HEntryPropertiesSerializer(serializers.Serializer):
-
     name = FlattenedStringField(required=False)
     content = ContentField(required=False)
     category = serializers.ListSerializer(child=serializers.CharField(), required=False, write_only=True)
@@ -168,7 +167,6 @@ ResponseTypeChoices = [("id", "id"), ("code", "id+authorization")]
 
 
 class IndieAuthAuthorizationSerializer(serializers.Serializer):
-
     me = serializers.URLField(required=False)
     client_id = serializers.URLField(required=True)
     redirect_uri = serializers.URLField(required=True)

--- a/apps/interfaces/public/indieweb/views.py
+++ b/apps/interfaces/public/indieweb/views.py
@@ -170,7 +170,6 @@ def micropub(request):  # noqa: C901 too complex (30)
     form = form_class(data=form_data, p_author=indieauth.queries.get_user_for_token(key=token))
 
     if form.is_valid() and all(named_form.is_valid() for named_form in named_forms.values()):
-
         handler = _determine_handler(form)
         entry = handler(form, named_forms, serializer)
 

--- a/apps/interfaces/public/maps/views.py
+++ b/apps/interfaces/public/maps/views.py
@@ -6,7 +6,6 @@ from data.post.models import TPost
 
 
 def cluster_map(request):
-
     posts = TPost.objects.visible_for_user(request.user.id).filter(
         m_post_status__key=MPostStatuses.published, m_post_kind__key=MPostKinds.checkin
     )

--- a/apps/interfaces/public/streams/views.py
+++ b/apps/interfaces/public/streams/views.py
@@ -18,7 +18,6 @@ class StreamView(ListView):
         return get_object_or_404(MStream.objects.visible(self.request.user), slug=self.kwargs["stream_slug"])
 
     def get_queryset(self):
-
         return (
             TEntry.objects.visible_for_user(self.request.user.id)
             .exclude(t_post__visibility=Visibility.UNLISTED)

--- a/apps/interfaces/public/templatetags/indieweb.py
+++ b/apps/interfaces/public/templatetags/indieweb.py
@@ -13,5 +13,4 @@ class RenderRelme(template.Node):
 
 @register.tag(name="render_relme")
 def do_render_relme(parser, token):
-
     return RenderRelme()

--- a/apps/tanzawa_plugin/exercise/migrations/0001_initial.py
+++ b/apps/tanzawa_plugin/exercise/migrations/0001_initial.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/apps/tanzawa_plugin/exercise/migrations/0002_accesstoken_athlete_refreshtoken.py
+++ b/apps/tanzawa_plugin/exercise/migrations/0002_accesstoken_athlete_refreshtoken.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("exercise", "0001_initial"),

--- a/apps/tanzawa_plugin/exercise/migrations/0003_map_vendor_id.py
+++ b/apps/tanzawa_plugin/exercise/migrations/0003_map_vendor_id.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("exercise", "0002_accesstoken_athlete_refreshtoken"),
     ]

--- a/apps/tanzawa_plugin/health/migrations/0001_initial.py
+++ b/apps/tanzawa_plugin/health/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/apps/tanzawa_plugin/now/migrations/0001_initial.py
+++ b/apps/tanzawa_plugin/now/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/apps/tanzawa_plugin/now/migrations/0002_tnow_files.py
+++ b/apps/tanzawa_plugin/now/migrations/0002_tnow_files.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("files", "0005_update_verbose_names"),
         ("now", "0001_initial"),

--- a/apps/tanzawa_plugin/now/views.py
+++ b/apps/tanzawa_plugin/now/views.py
@@ -37,7 +37,6 @@ class PublicViewNow(generic.TemplateView):
     template_name = "now/now.html"
 
     def dispatch(self, request, *args, **kwargs):
-
         self.now: models.TNow | None = models.TNow.objects.first()
         if not self.now:
             self.now = models.TNow.objects.create()

--- a/apps/templates/entry/fragments/list_timestamp.html
+++ b/apps/templates/entry/fragments/list_timestamp.html
@@ -3,10 +3,10 @@
 {% if t_entry.t_post.is_draft %}
     Draft: {{ t_entry.updated_at|date:"M d, Y H:m" }}
 {% else %}
-    {% ifequal t_entry.t_post.dt_published|date:"d" day %}
+    {% if t_entry.t_post.dt_published|date:"d" == day %}
         {{ t_entry.created_at|naturaltime }}
     {% else %}
         {{ t_entry.t_post.dt_published|date:"M d, Y" }}
-    {% endifequal %}
+    {% endif %}
 {% endif %}
 </span>

--- a/apps/templates/entry/status_item.html
+++ b/apps/templates/entry/status_item.html
@@ -2,11 +2,11 @@
 
 <div class="flex-col">
     <header>
-        {% ifequal status.create_at|date:"d" day %}
+        {% if status.create_at|date:"d" == day %}
             {{ status.created_at|naturaltime }}
         {% else %}
             {{ status.created_at|date:"M d, Y" }}
-        {% endifequal %}
+        {% endif %}
     </header>
     <main class="content mb-2">
         {{ status.e_content|safe }}

--- a/apps/templates/public/entry/article_item.html
+++ b/apps/templates/public/entry/article_item.html
@@ -9,11 +9,11 @@
         {% endif %}
         <div>
             <time class="dt-published" datetime="{{ t_post.dt_published.isoformat }}">
-            {% ifequal t_post.dt_published|date:"d" now|date:"d" %}
+            {% if t_post.dt_published|date:"d" == now|date:"d" %}
                 {{ t_post.dt_published|naturaltime }}
             {% else %}
                 {{ t_post.dt_published|date:"M d, Y" }}
-            {% endifequal %}
+            {% endif %}
             </time>
             {% include 'author/byline.html' with p_author=t_post.p_author %}
             {% if t_entry.t_location %}

--- a/apps/templates/public/entry/bookmark_item.html
+++ b/apps/templates/public/entry/bookmark_item.html
@@ -12,11 +12,11 @@
         {% endif %}
         <div>
             <time class="dt-published" datetime="{{ t_post.dt_published.isoformat }}">
-            {% ifequal t_post.dt_published|date:"d" now|date:"d" %}
+            {% if t_post.dt_published|date:"d" == now|date:"d" %}
                 {{ t_post.dt_published|naturaltime }}
             {% else %}
                 {{ t_post.dt_published|date:"M d, Y" }}
-            {% endifequal %}
+            {% endif %}
             </time>
             {% include 'author/byline.html' with p_author=t_post.p_author %}
             {% if t_entry.t_location %}

--- a/apps/templates/public/entry/checkin_item.html
+++ b/apps/templates/public/entry/checkin_item.html
@@ -14,11 +14,11 @@
         </span>
         <div>
             <time class="dt-published" datetime="{{ t_post.dt_published.isoformat }}">
-            {% ifequal t_post.dt_published|date:"d" now|date:"d" %}
+            {% if t_post.dt_published|date:"d" == now|date:"d" %}
                 {{ t_post.dt_published|naturaltime }}
             {% else %}
                 {{ t_post.dt_published|date:"M d, Y" }}
-            {% endifequal %}
+            {% endif %}
             </time>
             {% include 'author/byline.html' with p_author=t_post.p_author %}
             {% if t_entry.t_location %}

--- a/apps/templates/public/entry/note_item.html
+++ b/apps/templates/public/entry/note_item.html
@@ -9,11 +9,11 @@
         {% endif %}
         <div class="italic">
             <time class="dt-published" datetime="{{ t_post.dt_published.isoformat }}">
-            {% ifequal t_post.dt_published|date:"d" now|date:"d" %}
+            {% if t_post.dt_published|date:"d" == now|date:"d" %}
                 {{ t_post.dt_published|naturaltime }}
             {% else %}
                 {{ t_post.dt_published|date:"M d, Y" }}
-            {% endifequal %}
+            {% endif %}
             </time>
             {% include 'author/byline.html' with p_author=t_post.p_author %}
             {% if t_entry.t_location %}

--- a/apps/templates/public/entry/reply_item.html
+++ b/apps/templates/public/entry/reply_item.html
@@ -11,11 +11,11 @@
         {% endif %}
         <div>
             <time class="dt-published" datetime="{{ t_post.dt_published.isoformat }}">
-            {% ifequal t_post.dt_published|date:"d" now|date:"d" %}
+            {% if t_post.dt_published|date:"d" == now|date:"d" %}
                 {{ t_post.dt_published|naturaltime }}
             {% else %}
                 {{ t_post.dt_published|date:"M d, Y" }}
-            {% endifequal %}
+            {% endif %}
             </time>
             {% include 'author/byline.html' with p_author=t_post.p_author %}
             {% if t_entry.t_location %}

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,5 +1,5 @@
-asgiref==3.3.2
-Django==3.2.16
+asgiref==3.6.0
+Django==4.2
 pytz==2022.7
 sqlparse==0.4.1
 django-webmention==3.0.0

--- a/tests/factories/post.py
+++ b/tests/factories/post.py
@@ -13,7 +13,6 @@ class _MPostKind(factory.django.DjangoModelFactory):
 
 
 class NoteKind(_MPostKind):
-
     key = "note"
 
 

--- a/tests/test_indieweb/test_micropub.py
+++ b/tests/test_indieweb/test_micropub.py
@@ -443,7 +443,6 @@ class TestMicropub:
         download_image_mock,
         factory,
     ):
-
         # Create an active trip
         trip = factory.Trip()
         factory.Settings(active_trip=trip)

--- a/tests/test_wordpress/test_forms.py
+++ b/tests/test_wordpress/test_forms.py
@@ -33,7 +33,6 @@ class TestWordpressUploadFrom:
         return {"export_file": export_file}
 
     def test_valid(self, target, form_data):
-
         form = target(files=form_data)
         assert form.is_valid()
 


### PR DESCRIPTION
Updates dependencies to Django 4.2.

As there is an incompatibility between Spatalite5 and SQLite 3.36, I had to introduce a pytest fixture that ensures the spatial metadata is created using the Spatalite5 schema, not Spatalite4 schema in order to run migrations.

Existing installs of Tanzawa will need to manually upgrade their database metadata before they can run this version by running the command ` spatialite_convert -d db.sqlite3 -tv 5`, as per the [Spatalite upgrade docs](https://www.gaia-gis.it/fossil/libspatialite/wiki?name=Upgrading+existing+DB-files+to+5.0.0).