### PR TITLE
Return a fix size for non-image attachments

### DIFF
--- a/apps/domain/files/queries.py
+++ b/apps/domain/files/queries.py
@@ -1,4 +1,7 @@
+from dataclasses import dataclass
+
 from django.db.models import QuerySet
+from PIL import Image, UnidentifiedImageError
 
 from core.constants import Visibility
 from data.files import models as file_models
@@ -24,3 +27,21 @@ def get_representative_image(post: post_models.TPost) -> file_models.TFile | Non
     Return the first image in a post that's used as the representative image.
     """
     return post.files.filter(mime_type__startswith="image").first()
+
+
+@dataclass(frozen=True)
+class Size:
+    width: int
+    height: int
+
+
+def get_size_for_file(t_file: file_models.TFile) -> Size:
+    """
+    Return the size for a given file.
+    """
+    try:
+        with Image.open(t_file.file) as image:
+            return Size(width=image.width, height=image.height)
+    except UnidentifiedImageError:
+        # Return a fixed size if case we upload a PDF or some non-Image file.
+        return Size(width=600, height=600)

--- a/apps/interfaces/dashboard/files/views.py
+++ b/apps/interfaces/dashboard/files/views.py
@@ -6,10 +6,10 @@ from django.db import transaction
 from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.views.generic import DeleteView, DetailView, ListView
-from PIL import Image
 from turbo_response.mixins import HttpResponseSeeOther, TurboFrameTemplateResponseMixin
 
 from data.files.models import TFile
+from domain.files import queries as file_queries
 
 
 @method_decorator(login_required, name="dispatch")
@@ -110,25 +110,22 @@ class TrixFigure(DetailView):
     def get_context_data(self, **kwargs):
         t_file: TFile = self.object
 
-        with Image.open(t_file.file) as image:
-            width = image.width
-            height = image.height
-
+        size = file_queries.get_size_for_file(t_file)
         img_src = self.request.build_absolute_uri(t_file.get_absolute_url())
         context = {
             "mime": self.object.mime_type,
             "src": img_src,
-            "width": width,
-            "height": height,
+            "width": size.width,
+            "height": size.height,
             "trix_attachment_data": json.dumps(
                 {
                     "contentType": self.object.mime_type,
                     "filename": self.object.filename,
                     "filesize": self.object.file.size,
-                    "height": height,
+                    "height": size.height,
                     "href": f"{img_src}?content-disposition=attachment",
                     "url": img_src,
-                    "width": width,
+                    "width": size.width,
                 }
             ),
         }


### PR DESCRIPTION
So I can insert pdf attachments after the original uploading.