### PR TITLE
Improve pdf upload handling

### DIFF
--- a/apps/data/files/constants.py
+++ b/apps/data/files/constants.py
@@ -7,6 +7,7 @@ SVG = "image/svg+xml"
 BMP = "image/bmp"
 ICO = "image/x-icon"
 TIFF = "image/tiff"
+PDF = "application/pdf"
 
 PICTURE_FORMATS = {
     GIF: [APNG],
@@ -17,4 +18,5 @@ PICTURE_FORMATS = {
     BMP: [JPEG, WEBP],
     ICO: [JPEG, WEBP],
     TIFF: [JPEG, WEBP],
+    PDF: [WEBP],
 }

--- a/apps/domain/files/operations.py
+++ b/apps/domain/files/operations.py
@@ -1,0 +1,68 @@
+from data.files import models as file_models
+from domain.files import queries as file_queries
+from domain.images import images as image_ops
+
+
+class UnprocessableFile(Exception):
+    ...
+
+
+def get_file(
+    t_file: file_models.TFile, target_mime: str, longest_edge: int | None = None
+) -> file_models.TFile | file_models.TFormattedImage:
+    """
+    Return the file or a processed (resized/format changed) file.
+    """
+    return_file = t_file
+    if target_mime == t_file.mime_type and longest_edge is None:
+        # They're requesting the original file so return early
+        return return_file
+
+    try:
+        if file_queries.can_process_file(target_mime):
+            return_file, _ = _get_or_create_processed_file(t_file, target_mime, longest_edge)
+        elif longest_edge:
+            return_file, _ = _get_or_create_processed_file(
+                t_file, target_mime=t_file.mime_type, longest_edge=longest_edge
+            )
+    except UnprocessableFile:
+        return t_file
+    else:
+        return return_file
+
+
+def _get_or_create_processed_file(
+    t_file: file_models.TFile, target_mime: str, longest_edge: int | None = None
+) -> tuple[file_models.TFormattedImage, bool]:
+    if processed_file := file_queries.get_processed_file(t_file, mime_type=target_mime, longest_edge=longest_edge):
+        return processed_file, False
+
+    return _create_processed_file(t_file, target_mime=target_mime, longest_edge=longest_edge), True
+
+
+def _create_processed_file(
+    t_file: file_models.TFile,
+    target_mime: str,
+    longest_edge: int | None = None,
+) -> file_models.TFormattedImage:
+    """
+    Resize and convert a t_file to a given format.
+
+    :raises UnprocessableFile
+    """
+    upload_file, width, height = image_ops.convert_image_format(
+        t_file, target_mime=target_mime, longest_edge=int(longest_edge) if longest_edge else None
+    )
+    if upload_file is None:
+        raise UnprocessableFile("Unable to process file")
+
+    formatted_file = file_models.TFormattedImage(
+        file=upload_file,
+        t_file=t_file,
+        mime_type=target_mime,
+        filename=upload_file.name,
+        width=width,
+        height=height,
+    )
+    formatted_file.save()
+    return formatted_file

--- a/apps/domain/files/queries.py
+++ b/apps/domain/files/queries.py
@@ -67,3 +67,8 @@ def get_processed_file(
     if longest_edge:
         qs = qs.filter(Q(width=longest_edge) | Q(height=longest_edge))
     return qs.first()
+
+
+def get_image_url(request, t_file: file_models.TFile) -> str:
+    img_url = request.build_absolute_uri(t_file.get_absolute_url())
+    return img_url

--- a/apps/domain/files/queries.py
+++ b/apps/domain/files/queries.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
 
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from PIL import Image, UnidentifiedImageError
 
 from core.constants import Visibility
+from data.files import constants as file_constants
 from data.files import models as file_models
 from data.indieweb.constants import MPostStatuses
 from data.post import models as post_models
@@ -45,3 +46,24 @@ def get_size_for_file(t_file: file_models.TFile) -> Size:
     except UnidentifiedImageError:
         # Return a fixed size if case we upload a PDF or some non-Image file.
         return Size(width=600, height=600)
+
+
+def can_process_file(mime_type: str | None) -> bool:
+    """
+    Return if we can process a mime type or not.
+    """
+    return mime_type in file_constants.PICTURE_FORMATS.keys()
+
+
+def get_processed_file(
+    t_file: file_models.TFile, mime_type: str | None = None, longest_edge: int | None = None
+) -> file_models.TFormattedImage | None:
+    """
+    Get a pre-processed file (thumbnail etc..) for a given file.
+    """
+    qs = t_file.ref_t_formatted_image.all()
+    if mime_type:
+        qs = qs.filter(mime_type=mime_type)
+    if longest_edge:
+        qs = qs.filter(Q(width=longest_edge) | Q(height=longest_edge))
+    return qs.first()

--- a/apps/domain/files/utils.py
+++ b/apps/domain/files/utils.py
@@ -1,6 +1,13 @@
+import re
+
+UUID_REGEX = re.compile(r"[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}", re.IGNORECASE)
+
+
 def extract_uuid_from_url(url: str) -> str:
     """
     input: http://127.0.0.1:8000/files/543e4f8e-464d-46ec-998b-d2e3e6b07243
     output: 543e4f8e-464d-46ec-998b-d2e3e6b07243
     """
-    return url.split("/")[-1]
+    if match := UUID_REGEX.search(url):
+        return match[0]
+    raise ValueError("UUID not found")

--- a/apps/domain/images/images.py
+++ b/apps/domain/images/images.py
@@ -6,7 +6,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils.timezone import now
 from PIL import Image, ImageOps
 
-from data.files.models import TFile
+from data.files import models as file_models
 
 
 def rotate_image(image_bytes: io.BytesIO, mime_type: str) -> io.BytesIO:
@@ -26,38 +26,50 @@ def rotate_image(image_bytes: io.BytesIO, mime_type: str) -> io.BytesIO:
     return rotated_bytes
 
 
-def convert_image_format(  # noqa: C901
-    t_file: TFile, target_mime: str, size: int | None = None
+def convert_image_format(
+    t_file: file_models.TFile, target_mime: str, longest_edge: int | None = None
 ) -> tuple[SimpleUploadedFile, int, int] | tuple[None, None, None]:
     image = Image.open(t_file.file)
-    new_image_data = io.BytesIO()
-    ext = mimetypes.guess_extension(target_mime)
-    if not ext:
+    file_extension = mimetypes.guess_extension(target_mime)
+    if not file_extension:
         # unknown mimetype, can't convert
         return None, None, None
 
     image = _get_rotated_image(image)
 
-    if size:
-        image = image.copy()
-        # thumbnail resizes in place. resize returns a new image instance
-        image.thumbnail((size, size))
+    if longest_edge:
+        image = _get_thumbnail(image, longest_edge)
     elif image.width >= 1200 or image.height >= 1200:
         width, height = (image.width // 2, image.height // 2)
         image = image.resize((width, height))
-    fmt = ext[1:]
 
-    if fmt == "jpg":
-        # .jpg fails but jpeg works ¯\_(ツ)_/¯
-        fmt = "jpeg"
-    image.save(new_image_data, format=fmt)
-    new_image_data.seek(0)
-    new_image = Image.open(new_image_data)
-    new_filename = t_file.filename.replace(Path(t_file.filename).suffix, ext)
-    new_image_data.seek(0)
-    upload_file = SimpleUploadedFile(new_filename, new_image_data.read(), target_mime)
+    new_format_data = _change_image_format(image, format=file_extension[1:])
+
+    new_image = Image.open(new_format_data)
+    new_filename = t_file.filename.replace(Path(t_file.filename).suffix, file_extension)
+    new_format_data.seek(0)
+
+    upload_file = SimpleUploadedFile(new_filename, new_format_data.read(), target_mime)
 
     return upload_file, new_image.width, new_image.height
+
+
+def _get_thumbnail(image: Image, longest_edge: int) -> Image:
+    image = image.copy()
+    # thumbnail resizes in place. resize returns a new image instance
+    image.thumbnail((longest_edge, longest_edge))
+    return image
+
+
+def _change_image_format(image: Image, format: str) -> io.BytesIO:
+    new_image_data = io.BytesIO()
+
+    if format == "jpg":
+        # .jpg fails but jpeg works ¯\_(ツ)_/¯
+        format = "jpeg"
+    image.save(new_image_data, format=format)
+    new_image_data.seek(0)
+    return new_image_data
 
 
 def _get_rotated_image(image: Image) -> Image:

--- a/apps/domain/images/images.py
+++ b/apps/domain/images/images.py
@@ -39,17 +39,17 @@ def convert_image_format(  # noqa: C901
     orientation = 274
     try:
         exif = image._getexif()
-        if exif:
-            exif = dict(exif.items())
-            if exif[orientation] == 3:
-                image = image.rotate(180, expand=True)
-            elif exif[orientation] == 6:
-                image = image.rotate(270, expand=True)
-            elif exif[orientation] == 8:
-                image = image.rotate(90, expand=True)
     except (AttributeError, KeyError):
         # There is AttributeError: _getexif sometimes.
         pass
+    else:
+        exif = dict(exif.items())
+        if exif[orientation] == 3:
+            image = image.rotate(180, expand=True)
+        elif exif[orientation] == 6:
+            image = image.rotate(270, expand=True)
+        elif exif[orientation] == 8:
+            image = image.rotate(90, expand=True)
 
     if size:
         image = image.copy()

--- a/apps/interfaces/dashboard/files/views.py
+++ b/apps/interfaces/dashboard/files/views.py
@@ -111,7 +111,7 @@ class TrixFigure(DetailView):
         t_file: TFile = self.object
 
         size = file_queries.get_size_for_file(t_file)
-        img_src = self.request.build_absolute_uri(t_file.get_absolute_url())
+        img_src = file_queries.get_image_url(self.request, t_file)
         context = {
             "mime": self.object.mime_type,
             "src": img_src,

--- a/apps/interfaces/public/files/views.py
+++ b/apps/interfaces/public/files/views.py
@@ -1,4 +1,3 @@
-from django.db.models import Q
 from django.http import (
     FileResponse,
     HttpResponse,
@@ -9,9 +8,8 @@ from django.http import (
 from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 
-from data.files.models import TFile, TFormattedImage
-from domain.files import queries as file_queries
-from domain.images.images import convert_image_format
+from data.files import models as file_models
+from domain.files import operations as file_ops
 
 from .forms import MediaUploadForm
 
@@ -39,45 +37,14 @@ def micropub_media(request):
 
 
 def get_media(request, uuid):
-    t_file: TFile = get_object_or_404(TFile, uuid=uuid)
-    return_file = t_file
+    t_file: file_models.TFile = get_object_or_404(file_models.TFile, uuid=uuid)
     as_attachment = request.GET.get("content-disposition", "inline") == "attachment"
-    file_format = request.GET.get("f")
+    file_format = request.GET.get("f") or t_file.mime_type
     size = request.GET.get("s")
 
-    if file_queries.can_process_file(file_format):
-        return_file = file_queries.get_processed_file(t_file, file_format, size)
-        if return_file is None:
-            upload_file, width, height = convert_image_format(
-                t_file, target_mime=file_format, size=int(size) if size else None
-            )
-            if upload_file:
-                formatted_file = TFormattedImage(
-                    file=upload_file,
-                    t_file=t_file,
-                    mime_type=file_format,
-                    filename=upload_file.name,
-                    width=width,
-                    height=height,
-                )
-                formatted_file.save()
-                return_file = formatted_file
-    elif size:
-        return_file = file_queries.get_processed_file(t_file, longest_edge=size)
-        if return_file is None:
-            upload_file, width, height = convert_image_format(t_file, target_mime=t_file.mime_type, size=int(size))
-            if upload_file:
-                formatted_file = TFormattedImage(
-                    file=upload_file,
-                    t_file=t_file,
-                    mime_type=t_file.mime_type,
-                    filename=upload_file.name,
-                    width=width,
-                    height=height,
-                )
-                formatted_file.save()
-                return_file = formatted_file
-    # If there was an error creating a smaller version, the file has already been read so reset to 0.
+    return_file = file_ops.get_file(t_file, file_format, size)
+
+    # Ensure we always return the entire file, despite potential processing.
     return_file.file.seek(0)
     response = FileResponse(
         return_file.file,

--- a/apps/templates/files/tfiles_browser.html
+++ b/apps/templates/files/tfiles_browser.html
@@ -11,7 +11,7 @@
             data-remote-url='{% url "file_detail" t_file.pk %}?page={{ page_obj.number }}&insert=1'
         >
             <div data-action='click->remote#view' class="cursor-pointer">
-                {% if "image" in t_file.mime_type %}
+                {% if "image" in t_file.mime_type or "pdf" in t_file.mime_type  %}
                     {#  208px ==  13rm #}
                     <picture>
                         <source srcset="{% url 'public:get_media' t_file.uuid %}?s=416&f=image/webp 2x" type="image/webp"/>

--- a/requirements.lock
+++ b/requirements.lock
@@ -30,3 +30,4 @@ envparse==0.2.0
 django-htmx==1.13.0
 polyline==1.4.0
 cairosvg==2.5.2
+PyMuPDF==1.22.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ phpserialize
 django-htmx
 polyline
 cairosvg
+PyMuPDF


### PR DESCRIPTION
This PR allows Tanzawa to preview PDFs in the file browser. It refactors the image getting logic to better match our domain architecture. When attempting to fetch a PDF with format / size arguments, it will rasterize the first page as a png to allow it to convert to the target mime (webp).

It also improves how we detect file references in existing posts by using regex instead of (very) naive splitting of a url.