### PR TITLE
Add Generation from Sunbottle to the homepage

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -18,7 +18,9 @@ TIME_ZONE=UTC
 STATIC_ROOT=./staticfiles/
 MEDIA_ROOT=./micropub_media/
 
-# macOS
+# macOS x86
 # SPATIALITE_LIBRARY_PATH=/usr/local/lib/mod_spatialite.dylib
+# macOS apple silicon
+# SPATIALITE_LIBRARY_PATH='/opt/homebrew/lib/mod_spatialite.dylib'
 
 HIGHLIGHT_STREAM_SLUG=the-week

--- a/apps/core/settings.py
+++ b/apps/core/settings.py
@@ -251,3 +251,8 @@ if env.bool("ENABLE_SENTRY", default=False):
         traces_sample_rate=1.0,
         send_default_pii=True,
     )
+
+
+# Sunbottle
+
+SUNBOTTLE_API_URL = env.str("SUNBOTTLE_API_URL", default="")

--- a/apps/domain/sunbottle/client.py
+++ b/apps/domain/sunbottle/client.py
@@ -1,0 +1,32 @@
+import requests
+from django.conf import settings
+
+
+class SunbottleClientError(Exception):
+    pass
+
+
+class SunbottleClient:
+    """
+    A client for interacting with Strava.
+    """
+
+    auth_token: str
+
+    def __init__(self, auth_token: str | None = None) -> None:
+        super().__init__()
+        self.auth_token = auth_token or ""
+
+    def get_generation(self) -> list[dict]:
+        summary_url = f"{settings.SUNBOTTLE_API_URL}generation_summary"
+        response = requests.get(summary_url, headers=self._get_headers())
+        if response.status_code == 200:
+            return response.json()
+        raise SunbottleClientError(response.json())
+
+    def _get_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.auth_token}"}
+
+
+def get_client(auth_token: str | None = None) -> SunbottleClient:
+    return SunbottleClient(auth_token=auth_token)

--- a/apps/domain/sunbottle/queries.py
+++ b/apps/domain/sunbottle/queries.py
@@ -1,0 +1,15 @@
+import functools
+
+from domain.sunbottle import client as sunbottle_client
+
+
+@functools.lru_cache(maxsize=2)
+def get_generation(hour: int):
+    """
+    Get the total generation from the configured Sunbottle instance.
+    """
+    client = sunbottle_client.get_client()
+    try:
+        return client.get_generation()
+    except sunbottle_client.SunbottleClientError:
+        return {}

--- a/apps/interfaces/public/home/views.py
+++ b/apps/interfaces/public/home/views.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.db.models import Count, Q
+from django.utils import timezone
 from django.views.generic import ListView, TemplateView
 
 from core.constants import Visibility
@@ -9,6 +10,7 @@ from data.post.models import MPostKind
 from data.streams.models import MStream
 from domain.files import queries as file_queries
 from domain.posts import queries as post_queries
+from domain.sunbottle import queries as sunbotte_queries
 
 
 class BlogListView(ListView):
@@ -93,4 +95,7 @@ class HomeView(TemplateView):
                 "photo_gallery": file_queries.get_public_photos(limit=10),
             }
         )
+        if settings.SUNBOTTLE_API_URL:
+            context["generation"] = sunbotte_queries.get_generation(timezone.now().time().hour)
+
         return context

--- a/apps/templates/public/home.html
+++ b/apps/templates/public/home.html
@@ -1,6 +1,6 @@
 {% extends "base_public.html" %}
 
-{% load plugins tz %}
+{% load plugins tz humanize %}
 
 {% block breadcrumbs_block %}{% endblock %}
 
@@ -93,6 +93,21 @@
                     {% endfor %}
                 </div>
             </div>
+
+            {% if generation %}
+            <div class="mt-2 md:flex md:mt-8">
+                <div class="md:flex flex-col flex-grow">
+                    <div class="mb-2 md:mb-4">
+                        <h1>☀️ Solar Generation</h1>
+                        <p>The <a href="https://solar.jamesvandyne.com" class="underline">solar panels</a> on my roof have generated:</p>
+                            <ol class="text-sm">
+                                <li>{{ generation.today_generation|intcomma }} kWh today</li>
+                                <li>{{ generation.total_generation|intcomma }} kWh total</li>
+                            </ol>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
         </div>
 
     </div>

--- a/apps/templates/public/home.html
+++ b/apps/templates/public/home.html
@@ -35,7 +35,7 @@
 
         </div>
             <div class="mt-2 md:flex md:mt-8">
-            <div class="md:flex flex-col flex-grow">
+                <div class="md:flex flex-col flex-grow">
                 {% if highlight_kind.kind %}
                 <div class="mb-2 md:mb-4">
                     <h1>{{ highlight_kind.kind.icon }} {{ highlight_kind.kind.name }}{{ highlight_kind.posts|pluralize:"s" }}</h1>
@@ -61,8 +61,7 @@
                 </div>
                 {% endif %}
             </div>
-
-            <div class="mt-2 md:mt-0 md:flex flex-col">
+                <div class="mt-2 md:mt-0 md:flex flex-col">
                 <h1>🌏 Last seen...</h1>
                 <ul class="">
                     {% if last_seen.last_location_post %}
@@ -82,8 +81,7 @@
                     </div>
                 {% endif %}
             </div>
-
-        </div>
+            </div>
             <div class="mt-2 md:mt-8">
                 <h1>📸 Photos</h1>
                 <div class="mt-2 grid grid-cols-3 gap-2 md:grid-cols-5">

--- a/tests/test_public/test_home_view.py
+++ b/tests/test_public/test_home_view.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from django.urls import reverse
 from model_bakery import baker
@@ -61,5 +63,7 @@ class TestHomeView:
     ):
         if login_user:
             client.force_login(login_user)
-        response = client.get(target_url)
+
+        with mock.patch("interfaces.public.home.views.sunbotte_queries"):
+            response = client.get(target_url)
         assert should_show == (t_entry.p_summary in response.content.decode("utf-8"))


### PR DESCRIPTION
This PR adds a small section on the homepage which shows some basic generation stats from Sunbottle.


<img width="375" alt="image" src="https://github.com/jamesvandyne/tanzawa/assets/154726/bd10537b-d72f-4dbf-b2e5-7739abe6c070">
