### PR TITLE
Health graph date filter

### DIFF
--- a/apps/tanzawa_plugin/health/admin_urls.py
+++ b/apps/tanzawa_plugin/health/admin_urls.py
@@ -6,6 +6,7 @@ app_name = "plugin_health_admin"
 
 urlpatterns = [
     path("daily_health/", views.AddDailyHealth.as_view(), name="add_daily_health"),
+    path("weight_graph/", views.WeightGraph.as_view(), name="weight_graph"),
     path("graph_api/", views.graph_api, name="graph_api"),
     path("", views.Health.as_view(), name="health"),
 ]

--- a/apps/tanzawa_plugin/health/constants.py
+++ b/apps/tanzawa_plugin/health/constants.py
@@ -16,3 +16,10 @@ class EmojiMoodChoices(TextChoices):
     POSITIVE = "positive", "😀"
     NEUTRAL = "neutral", "😐"
     NEGATIVE = "negative", "☹️"
+
+
+class GraphDuration(TextChoices):
+    SIX_WEEKS = "SIX_WEEKS", "Six Weeks"
+    MONTH_TO_DATE = "MONTH_TO_DATE", "Month to date"
+    LAST_MONTH = "LAST_MONTH", "Last Month"
+    ALL = "ALL", "All"

--- a/apps/tanzawa_plugin/health/forms.py
+++ b/apps/tanzawa_plugin/health/forms.py
@@ -1,4 +1,4 @@
-from django import forms
+from django import forms, urls
 
 from . import constants
 
@@ -20,4 +20,15 @@ class DailyCheckinForm(forms.Form):
         label="How do you feel?",
         widget=forms.RadioSelect(attrs={"class": "peer appearance-none hidden"}),
         help_text="For real. You're not fooling anybody.",
+    )
+
+
+class WeightGraph(forms.Form):
+    duration = forms.ChoiceField(
+        choices=constants.GraphDuration.choices,
+        initial=constants.GraphDuration.SIX_WEEKS,
+        widget=forms.Select(
+            attrs={"hx-get": urls.reverse_lazy("plugin_health_admin:weight_graph"), "hx-target": "#chart"}
+        ),
+        required=False,
     )

--- a/apps/tanzawa_plugin/health/queries.py
+++ b/apps/tanzawa_plugin/health/queries.py
@@ -1,0 +1,39 @@
+import datetime
+
+import arrow
+from django.db.models import Q
+from django.utils import timezone
+
+from . import constants
+
+
+def get_date_filter(duration: constants.GraphDuration | None = None) -> Q | None:
+    """
+    Return the Q object for a given duration.
+    """
+    match duration:
+        case constants.GraphDuration.SIX_WEEKS:
+            return Q(measured_at__date__gte=_get_six_weeks_ago())
+        case constants.GraphDuration.MONTH_TO_DATE:
+            return Q(measured_at__date__gte=_get_first_of_month())
+        case constants.GraphDuration.LAST_MONTH:
+            last_month = _get_last_month()
+            return Q(measured_at__range=[d.datetime for d in last_month])
+        case [constants.GraphDuration.ALL, _]:
+            return None
+    return None
+
+
+def _get_six_weeks_ago() -> datetime.date:
+    six_weeks_ago = arrow.get(timezone.now()).shift(weeks=-6)
+    return six_weeks_ago.date()
+
+
+def _get_first_of_month() -> datetime.date:
+    now = timezone.now()
+    return datetime.date(year=now.year, month=now.month, day=1)
+
+
+def _get_last_month() -> tuple[arrow.Arrow, arrow.Arrow]:
+    last_month = arrow.get(timezone.now()).shift(months=-1)
+    return last_month.span("month")

--- a/apps/tanzawa_plugin/health/templates/health/fragments/weight_graph.html
+++ b/apps/tanzawa_plugin/health/templates/health/fragments/weight_graph.html
@@ -1,0 +1,50 @@
+<div id="chart">
+    {{ form }}
+    <section class="mt-2">
+        <canvas id="weightChart" width="400" height="300" class="max-w-prose" style="height: 300px;"></canvas>
+    </section>
+</div>
+
+
+<script>
+
+async function drawChart() {
+    let ctx = document.getElementById('weightChart');
+    const response = await fetch("{% url 'plugin_health_admin:graph_api' %}?duration={{ duration }}");
+    const data = await response.json();
+    const weightChart = new Chart(ctx, {
+        type: "line",
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                title: {
+                    display: true,
+                    text: 'Weight',
+                    color: "#938070",
+                },
+                 legend: {
+                    display: true,
+                     position: "bottom",
+                    labels: {
+                        color: "#938070"
+                    }
+                }
+            }
+        },
+        data: {
+            labels: data.labels,
+            datasets: [
+                {
+                    label: "{{ weight.unit }}",
+                    data: data.weight,
+                    fill: true,
+                    borderColor: "#11722c",
+                    pointRadius: 0,
+                },
+            ],
+        },
+    });
+}
+drawChart();
+</script>

--- a/apps/tanzawa_plugin/health/templates/health/health.html
+++ b/apps/tanzawa_plugin/health/templates/health/health.html
@@ -25,55 +25,7 @@
                 <p class="text-4xl">{{ mood.emoji }}</p>
             </div>
         </section>
-        <section class="mt-2">
-            <canvas id="weightChart" width="400" height="300" class="max-w-prose" style="height: 300px;"></canvas>
-        </section>
+        <div hx-get="{% url "plugin_health_admin:weight_graph" %}" hx-trigger="load"></div>
         {% endif %}
     </main>
-{% endblock %}
-
-
-{% block body_end %}
-    <script>
-    const ctx = document.getElementById('weightChart');
-
-    async function drawChart() {
-        const response = await fetch("{% url 'plugin_health_admin:graph_api' %}");
-        const data = await response.json();
-        const weightChart = new Chart(ctx, {
-            type: "line",
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                plugins: {
-                    title: {
-                        display: true,
-                        text: 'Last 10 measurements',
-                        color: "#938070",
-                    },
-                     legend: {
-                        display: true,
-                         position: "bottom",
-                        labels: {
-                            color: "#938070"
-                        }
-                    }
-                }
-            },
-            data: {
-                labels: data.labels,
-                datasets: [
-                    {
-                        label: "{{ weight.unit }}",
-                        data: data.weight,
-                        fill: true,
-                        borderColor: "#11722c",
-                        pointRadius: 0,
-                    },
-                ],
-            },
-        });
-    }
-    drawChart();
-</script>
 {% endblock %}

--- a/apps/tanzawa_plugin/health/views.py
+++ b/apps/tanzawa_plugin/health/views.py
@@ -46,6 +46,26 @@ class AddDailyHealth(generic.FormView):
         return super().form_valid(form)
 
 
+@util_decorators.method_decorator(auth_decorators.login_required, name="dispatch")
+class WeightGraph(generic.TemplateView):
+    """
+    A view that displays a weight data graph.
+    """
+
+    template_name = "health/fragments/weight_graph.html"
+
+    def setup(self, request, *args, **kwargs) -> None:
+        super().setup(request, *args, **kwargs)
+        try:
+            self.duration = constants.GraphDuration(request.GET.get("duration"))
+        except ValueError:
+            self.duration = constants.GraphDuration(constants.GraphDuration.SIX_WEEKS)
+
+    def get_context_data(self, **kwargs) -> dict:
+        form = forms.WeightGraph(self.request.GET)
+        return super().get_context_data(duration=self.duration, form=form)
+
+
 @auth_decorators.login_required
 def graph_api(request) -> http.JsonResponse:
     try:

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,3 +1,4 @@
+arrow==1.2.3
 asgiref==3.6.0
 Django==4.2.1
 pytz==2022.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -c requirements.lock
 
-
+arrow
 Django
 envparse
 django-meta

--- a/tests/tanzawa_plugins/health/test_queries.py
+++ b/tests/tanzawa_plugins/health/test_queries.py
@@ -1,0 +1,15 @@
+import datetime
+
+import freezegun
+
+from tanzawa_plugin.health import queries
+
+
+class TestGetDateFilter:
+    @freezegun.freeze_time("2023-06-16", tick=False)
+    def test_six_weeks(self):
+        assert datetime.date(2023, 5, 5) == queries._get_six_weeks_ago()
+
+    @freezegun.freeze_time("2023-06-16", tick=False)
+    def test_first_of_month(self):
+        assert datetime.date(2023, 6, 1) == queries._get_first_of_month()


### PR DESCRIPTION
Before this PR the graph on the weight page was fixed to the last 10 records. Useful, but it could be better.

After this PR Tanzawa displays a select dropdown that allows users to toggle between 4 different durations:

* Six Weeks
* Month to date
* Last month
* All


https://github.com/jamesvandyne/tanzawa/assets/154726/66085b91-1255-4347-be07-6eb6e5452a60

