### PR TITLE
Fix blurry photos on checkin

### DIFF
--- a/apps/application/feeds/content.py
+++ b/apps/application/feeds/content.py
@@ -12,8 +12,10 @@ def get_encoded_content(*, post: post_models.TPost) -> str:
     br_tag = "<br/>"
     content = queries.get_encoded_content(post)
     for feed_plugin in plugin_pool.feed_plugins():
-        before_content.append(feed_plugin.feed_before_content(post=post))
-        after_content.append(feed_plugin.feed_after_content(post=post))
+        if plugin_before_content := feed_plugin.feed_before_content(post=post):
+            before_content.append(plugin_before_content)
+        if plugin_after_content := feed_plugin.feed_after_content(post=post):
+            after_content.append(plugin_after_content)
 
     if before_content:
         content = f"{br_tag.join(before_content)}{br_tag}{content}"

--- a/apps/domain/files/queries.py
+++ b/apps/domain/files/queries.py
@@ -66,6 +66,11 @@ def get_processed_file(
         qs = qs.filter(mime_type=mime_type)
     if longest_edge:
         qs = qs.filter(Q(width=longest_edge) | Q(height=longest_edge))
+    else:
+        # Ensure we do not return a thumbnail sized photo when requesting the original without a
+        # specified size as it causes photos to become blurry.
+        original_size = get_size_for_file(t_file)
+        qs = qs.filter(Q(width=original_size.width) | Q(height=original_size.height))
     return qs.first()
 
 

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,6 +1,6 @@
 arrow==1.2.3
 asgiref==3.6.0
-Django==4.2.1
+Django==4.2.4
 pytz==2022.7
 sqlparse==0.4.1
 django-webmention==3.0.0


### PR DESCRIPTION
Before this PR:

* When fetching an image with a given format without a specified size, Tanzawa would return the first image in the format no matter the size. This resulted in Tanzawa returning thumbnail sized photos for images that were displayed much much larger.
* Each plugin that adjusted feed content would add a newline to the start of posts. This made weird spacing when reading posts in a feed reader.

After this PR:

* When fetching an image with just a target format specified, Tanzawa will return a picture of the same size in a different format.
* Tanzawa only adds newlines between feed content plugins if there's content returned by the plugin.
* Django upgraded to the latest version.