### PR TITLE
Pass timezone to arrow when getting activity time

### DIFF
--- a/apps/tanzawa_plugin/exercise/application/strava/_create_post_from_exercise.py
+++ b/apps/tanzawa_plugin/exercise/application/strava/_create_post_from_exercise.py
@@ -56,7 +56,7 @@ def _create_post_from_activity(
     """
     status = post_queries.get_post_status(MPostStatuses.published)
     post_kind = post_queries.get_post_kind(MPostKinds.note)
-    activity_time = arrow.get(activity_detail["start_date_local"]).to(activity_detail["timezone"]).datetime
+    activity_time = arrow.get(activity_detail["start_date_local"], tzinfo=activity_detail["timezone"]).datetime
     if activity.entry:
         entry = entry_ops.update_entry(
             entry=activity.entry,


### PR DESCRIPTION
Start date local has a Z on it, which implies it's UTC, however it's actually localtime (as the name implies).

Using .to(timezone) results in the datetime being adjusted, and when you're ahead of GMT, means posts won't be accessible until UTC catches up with localtime. So for Japan this is 9 hours later.

Pass in the timezone directly so the resulting datetime is localtime with a timezone.