### PR TITLE
Ensure bookmarks can filter multi-word tags

### DIFF
--- a/apps/interfaces/public/entry/views.py
+++ b/apps/interfaces/public/entry/views.py
@@ -56,7 +56,9 @@ class Bookmarks(generic.ListView):
 
     def get_queryset(self):
         qs = self._get_base_queryset()
-        form = forms.BookmarksSearchForm(self.request.GET)
+        # Ensure all tags are wrapped in quotes to account for tags which are multiple words
+        tag_names = " ".join([f'"{tag_name}"' for tag_name in self.request.GET._getlist("tag", [])])
+        form = forms.BookmarksSearchForm({"tag": tag_names})
         if form.is_valid():
             if form.cleaned_data["tag"]:
                 qs = qs.filter(t_post__tags__name__in=form.cleaned_data["tag"])


### PR DESCRIPTION
Before this commit filtering bookmarks by tags with a space in them e.g. "climate change" would search for items tagged "climate" and "change".

After this commit we quote all tags that are passed in so in the example above we'd search for "climate change".

This also has the side benefit of allowing us to pass _multiple_ tags in and Tanzawa filters by both tags.