### PR TITLE
Strava bits and bobs

### DIFF
--- a/apps/tanzawa_plugin/exercise/templates/exercise/exercise.html
+++ b/apps/tanzawa_plugin/exercise/templates/exercise/exercise.html
@@ -21,7 +21,7 @@
                     <h1 class="text-xl">Activities</h1>
                     <ol>
                         {% for activity in activities %}
-                            <li class="mt-2" hx-get="{% url "plugin_exercise_admin:activity_detail" activity.pk %}"  hx-trigger="click" hx-target="body" hx-swap="beforeend">
+                            <li class="mt-2 cursor-pointer" hx-get="{% url "plugin_exercise_admin:activity_detail" activity.pk %}"  hx-trigger="click" hx-target="body" hx-swap="beforeend">
                                 <div class="flex">
                                     <div class="w-full md:w-96">
                                         <h1>{{ activity.name }}</h1>


### PR DESCRIPTION
Use correct timezone when creating posts from Strava

The field name "timezone" implies that it is just a timezone i.e. "Asia/Tokyo" or similar. However, they are in a format like "(GMT+9:00) Asia/Tokyo". Use just the "Asia/Tokyo" part when creating posts from Strava.