### PR TITLE
Stop attempting to json decode error responses from Sunbottle

### DIFF
--- a/apps/domain/sunbottle/client.py
+++ b/apps/domain/sunbottle/client.py
@@ -22,7 +22,7 @@ class SunbottleClient:
         response = requests.get(summary_url, headers=self._get_headers())
         if response.status_code == 200:
             return response.json()
-        raise SunbottleClientError(response.json())
+        raise SunbottleClientError()
 
     def _get_headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self.auth_token}"}


### PR DESCRIPTION
Sunbottle generally returns json, but there are cases where it does not (e.g. 503 timeouts and the like).

Sunbottle information on the homepage is very much a "nice to have" and not critical so only attempt to process 200 OK responses.